### PR TITLE
Fix link to ISO 27091 (iso.org) as old lead to "404 Not Found"

### DIFF
--- a/index.md
+++ b/index.md
@@ -230,7 +230,7 @@ The version of the draft act to go into the next stage is expected mid-June 2023
 # Project status
 This page is the current outcome of the project. The goal is to collect and present the state of the art on these topics through community collaboration. First in the form of this page, and later in other document forms. Please provide your input through pull requests / submitting issues (see [repo](https://github.com/OWASP/www-project-ai-security-and-privacy-guide/)) or emailing the project lead, and let's make this guide better and better. 
 
-The work in this guide will serve as input to the upcoming [ISO/IEC 27090 (AI security)](https://www.iso.org/standard/56581.html) and [27091 (AI privacy)](https://standardsdevelopment.bsigroup.com/projects/9022-07819#/section) standards, which will be done through membership of the ISO/IEC JTC 1/SC42 AHG4 group.
+The work in this guide will serve as input to the upcoming [ISO/IEC 27090 (AI security)](https://www.iso.org/standard/56581.html) and [27091 (AI privacy)](https://www.iso.org/standard/56582.html) standards, which will be done through membership of the ISO/IEC JTC 1/SC42 AHG4 group.
 
 # Further reading
 


### PR DESCRIPTION
Changed Url to ISO 27091 (AI Privacy) from
https://standardsdevelopment.bsigroup.com/projects/9022-07819#/section (404 - Page not found)
to:
https://www.iso.org/standard/56582.html