### PR TITLE
Fix membership inference link

### DIFF
--- a/content/ai_exchange/content/docs/ai_security_overview.md
+++ b/content/ai_exchange/content/docs/ai_security_overview.md
@@ -577,7 +577,7 @@ Discovering potential risks that could impact the organization requires the tech
     - [unwanted disclosure in model output](/goto/disclosureuse/)
     - [model inversion](/goto/modelinversionandmembership/) 
     - [training data leaking from your engineering environment](/goto/devdataleak/).
-    - [membership inference]((/goto/modelinversionandmembership/)) - but only when the fact that something or someone was part of the training data constitutes sensitive information. For example, when the training set consists of criminals and their history to predict criminal careers. Membership of that set gives away the person is a convicted or alleged criminal.
+    - [membership inference](/goto/modelinversionandmembership/) - but only when the fact that something or someone was part of the training data constitutes sensitive information. For example, when the training set consists of criminals and their history to predict criminal careers. Membership of that set gives away the person is a convicted or alleged criminal.
     
   Question: do you use RAG?
   - Yes: apply the above to your augmentation data, as if it was part of the training set: as the repository data feeds into the model and can therefore be part of the output as well.


### PR DESCRIPTION
This pull request fixes a broken link in the AI Security Overview documentation on owaspai.org.

Specifically, it corrects the “membership inference” link in
https://owaspai.org/docs/ai_security_overview/

The original link contained an extra pair of parentheses () in the URL, which caused a redirection to a non-existent page:

```
https://owaspai.org/docs/ai_security_overview/%28/goto/modelinversionandmembership/%29
```

The link has been updated, restoring proper navigation and preventing 404 errors.