### PR TITLE
Harden CI and OpenCRE fetch reliability.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,11 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Add any build steps here. For example:
       # - run: npm ci && npm run build
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.147.0'
           extended: true

--- a/.github/workflows/pr_deploy.yml
+++ b/.github/workflows/pr_deploy.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.147.0'
           extended: true
@@ -52,11 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.147.0'
           extended: true

--- a/scripts/opencre-enrich/opencre-client.js
+++ b/scripts/opencre-enrich/opencre-client.js
@@ -28,7 +28,8 @@ function backoffDelayMs(attemptIndex, opts) {
 }
 
 function isRetryableHttpStatus(status) {
-  return [408, 429, 500, 502, 503, 504].includes(status);
+  // OpenCRE can intermittently return 530 from edge infrastructure; treat as transient.
+  return [408, 429, 500, 502, 503, 504, 530].includes(status);
 }
 
 /**


### PR DESCRIPTION
Upgrade deprecated GitHub Actions versions for Node 24 readiness and retry transient OpenCRE 530 responses during enrichment to reduce flaky build failures.

Made-with: Cursor