### PR TITLE
monitor-use: add tamper-evident logging bullet

### DIFF
--- a/content/ai_exchange/content/docs/2_threats_through_use.md
+++ b/content/ai_exchange/content/docs/2_threats_through_use.md
@@ -103,6 +103,11 @@ For each monitored risk, criteria can be defined to identify suspicious patterns
   - Response context: output content, post-processing steps, filtering or blocking actions.
   - Logs are retained for a period sufficient to support analysis, in alignment with legal and contractual requirements.
 
+  **- Tamper-evident logging:**  
+  Logs only help post-incident if they can be shown to be unmodified after the fact. The completeness and accuracy concession in the Limitations subsection assumes the stored records are trustworthy on read-back, which is not automatic. A signed-receipt approach binds a hash of input, output, and processing context to a per-event signature, and pairs that signature with an independent time anchor (for example an RFC 3161 Time-Stamp Authority) so that "when" cannot be backdated by whoever holds the signing key. For operators with multi-year retention or regulated-sector audit horizons, plan now for hybrid or post-quantum signature schemes alongside classical ones. One open profile that sets out the receipt-format obligations under EU AI Act, DORA, and US sector regulations is described in [draft-marques-asqav-compliance-receipts-04](https://datatracker.ietf.org/doc/draft-marques-asqav-compliance-receipts/04/).
+  
+  *Affiliation disclosure: I edit the cited IETF draft.*
+
   **- Incident qualification and alerting:**  
   When suspicious behavior is detected, monitoring supports:
 


### PR DESCRIPTION
## Summary

Adds a bullet under `#MONITOR USE` in `content/ai_exchange/content/docs/2_threats_through_use.md` on tamper-evident logging, sitting between the existing "Logging and traceability" and "Incident qualification and alerting" bullets.

The bullet covers three building blocks: signed per-event receipts that bind hashes of input/output/processing context to a verifiable signature; independent time anchoring (for example an RFC 3161 Time-Stamp Authority) so the "when" cannot be backdated by whoever holds the signing key; and forward planning for hybrid or post-quantum signature schemes on multi-year retention horizons.

The existing Limitations subsection already concedes that monitoring depends on "the completeness and accuracy of logged data" - this bullet closes the gap between that concession and what post-incident reconstruction needs in practice (externally verifiable records).

## Why here

The existing "Logging and traceability" bullet defines what to log and a retention horizon, but does not address how to make the stored records verifiable after the fact. Tamper-evident logging is a known-substantive gap, not a new control; it complements the existing guidance without displacing anything.

## Citation

Cites the IETF profile `draft-marques-asqav-compliance-receipts-04` (published 2026-05-19 on Datatracker) which sets out receipt-format obligations under EU AI Act, DORA, NIST AI RMF, and US sector regulations. RFC 3161 is named in prose as the standard time-anchor mechanism, without a separate link.

## Disclosure

I am the editor of the cited IETF draft. Disclosed inline in the bullet itself.

## Test plan

- [ ] Diff is +5 lines, single file (`2_threats_through_use.md`).
- [ ] Builds locally with Hugo using the existing site config.
- [ ] No new external links beyond the inline Datatracker URL.