### PR TITLE
Add GoatCounter analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm run serve         # Serve at http://localhost:3000
 
 **If you get** `permission denied` **on** `/var/lib/snapd/void` **when using a system-installed Hugo:** that's the Snap sandbox. Either run `sudo snap install hugo --classic` or use the commands above—they use `npx hugo-extended` so no system Hugo is needed.
 
+### Analytics
+
+The live site uses [GoatCounter](https://www.goatcounter.com/) for privacy-friendly pageview statistics (which pages are read, not who is reading them). The tracking snippet lives in `content/ai_exchange/layouts/partials/analytics.html` and is included from `layouts/_default/baseof.html`. Dashboard access and weekly email reports are managed in the GoatCounter account (`aix.goatcounter.com`).
+
 ## Contributions
 
 The OWASP projects are an open source effort, and we enthusiastically welcome all forms of contributions and feedback.

--- a/content/ai_exchange/content/contribute.md
+++ b/content/ai_exchange/content/contribute.md
@@ -198,6 +198,25 @@ weight: 1
   </div>
 </div>
 
+<div class="py-16 px-4 sm:px-6 lg:px-8 bg-white border-t border-gray-200">
+  <div class="container mx-auto p-0 max-w-3xl">
+    <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-6 text-center">
+      Site analytics
+    </h2>
+    <div class="text-gray-700 font-roboto text-base sm:text-lg leading-relaxed text-center">
+      <p class="mb-4">
+        This website uses <a href="https://www.goatcounter.com/" target="_blank" rel="noopener" class="text-green-600 font-medium underline">GoatCounter</a> to count page views so we can see which content is most useful and improve the guide over time.
+      </p>
+      <p class="mb-4">
+        GoatCounter is privacy-friendly: it does not use cookies, does not track individuals across websites, and does not sell data. We use it only for aggregate readership statistics.
+      </p>
+      <p>
+        Questions? <a href="/connect" class="text-green-600 font-medium underline">Contact the project team</a>.
+      </p>
+    </div>
+  </div>
+</div>
+
 <div class="py-16 px-2 sm:px-4 lg:px-8 bg-[#F1F1F1]">
   <div class="container mx-auto p-0">
     <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-8 text-center">

--- a/content/ai_exchange/layouts/_default/baseof.html
+++ b/content/ai_exchange/layouts/_default/baseof.html
@@ -7,5 +7,6 @@
     {{ partial "header.html" . }}
     <main id="main">{{ block "main" . }}{{ end }}</main>
     {{ partial "footer.html" . }}
+    {{ partial "analytics.html" . }}
   </body>
 </html>

--- a/content/ai_exchange/layouts/partials/analytics.html
+++ b/content/ai_exchange/layouts/partials/analytics.html
@@ -1,0 +1,2 @@
+<script data-goatcounter="https://aix.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION
## Summary
- Add GoatCounter pageview tracking (`aix.goatcounter.com`) via a Hugo layout partial included on every page
- Add a public **Site analytics** notice on the contribute page explaining what is collected and why
- Document analytics setup for maintainers in `README.md`

## Test plan
- [ ] Merge and deploy to production
- [ ] Visit owaspai.org with adblock disabled and confirm pageviews appear in the GoatCounter dashboard within ~10 seconds
- [ ] Confirm `/contribute` shows the new Site analytics section
- [ ] Optionally enable weekly email reports in GoatCounter user preferences


Made with [Cursor](https://cursor.com)