### PR TITLE
Add VASP failure-mode taxonomy reference to agentic AI threats section

### DIFF
--- a/content/ai_exchange/content/docs/ai_security_overview.md
+++ b/content/ai_exchange/content/docs/ai_security_overview.md
@@ -424,6 +424,23 @@ See [Simon Willison’s excellent work](https://simonwillison.net/2025/Jun/16/th
 
 [Prompt injection](/go/promptinjection/) and mostly the [indirect](/go/indirectpromptinjection/) form is the key threat in most agentic AI systems. See the [seven layers section](/go/promptinjectionsevenlayers/) on how these controls form layers of protection. After model alignment and filtering and detection, it should be assumed that prompt injection can still happen and therefore it is critical that _blast radius control_ is performed.
 
+For teams that need a consistent way to name and track agentic failure modes across reviews and reports, VASP (Verified Agent Security Protocol) is an open taxonomy (CC BY 4.0) of ten runtime behavioural failure modes — at the configuration and architecture level rather than the model level — each mapped to a CWE:
+
+| ID | Failure mode | CWE |
+|---|---|---|
+| VAF-001 | Approval Gate Bypass | CWE-285 |
+| VAF-002 | Policy Bound Violation | CWE-284 |
+| VAF-003 | Prompt Injection Tool Reachability | CWE-77 |
+| VAF-004 | Goal Divergence Under Distribution Shift | CWE-682 |
+| VAF-005 | Tool Scope Escalation | CWE-269 |
+| VAF-006 | Context Window Constraint Drop | CWE-119 |
+| VAF-007 | Multi-Agent Collusion Path | CWE-362 |
+| VAF-008 | PII Exfiltration via Unguarded Output | CWE-359 |
+| VAF-009 | RAG Retrieval Poisoning | CWE-346 |
+| VAF-010 | Persistent Memory Bias Accumulation | CWE-400 |
+
+Each mode is stated as a formal SMT (Z3) proof condition over the agent's configuration, where SAT means the vulnerable configuration is reachable and UNSAT means it has been ruled out. This makes the taxonomy usable as a checklist and as a machine-checkable specification. Full standard: [VASP](https://vasp-standard.vercel.app) (CC BY 4.0).
+
 Further links:
 - For more details on the agentic AI threats, see the [Agentic AI threats and mitigations, from the GenAI security project](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/).
 - For a more general discussion of Agentic AI, see [this article from Chip Huyen](https://huyenchip.com/2025/01/07/agents.html).


### PR DESCRIPTION
Closes the content side of #156.

### What this adds

One paragraph and a ten-row table in `ai_security_overview.md`, inside **Threats to agentic AI** (`/go/agenticaithreats/`), immediately before the existing *Further links* list. Roughly 1.2 KB. No existing text is modified, moved or removed.

It adds a reference to **VASP (Verified Agent Security Protocol)** — an open CC BY 4.0 taxonomy of ten runtime behavioural failure modes in agent systems, each mapped to a CWE.

### Why here

The section currently describes agentic threats well in prose and links out to sibling OWASP work for depth. What it doesn't yet offer is a compact, citable set of *named* failure modes a reader can use as a review checklist. That is the gap this fills, and it stays consistent with how the section already works: short framing, then references.

### Why a taxonomy rather than controls

VASP deliberately does not prescribe controls. Each mode is stated as a satisfiability condition over system configuration — `SAT` means the vulnerable configuration is reachable, `UNSAT` means it has been ruled out — so a mitigation claim becomes mechanically checkable rather than editorially asserted. Keeping naming separate from mitigation means the taxonomy can be cited alongside any control framework instead of competing with one.

This is relevant to two sibling threads:

- **#188** (@apeiris-ai) proposes the control layer, and maps several of its controls one-to-one onto these modes. I've posted the full cross-walk there and support that work landing first or in parallel — the layers are complementary, not overlapping.
- **#177** (@craigamcw) proposes provenance receipts as audit evidence, which is the third layer: naming, control, evidence.

I'd rather these land as a coherent set than as three competing proposals, so I'm happy to reorder, trim, or fold this into whatever shape the maintainers prefer.

### Provenance and licensing

- Standard: https://vasp-standard.vercel.app
- License: CC BY 4.0 — quote or adapt freely with attribution, no ShareAlike or other constraint
- Author: Dominik Blain, IronProof (affiliation disclosed; not seeking endorsement)

### Happy to adjust

If a full table is heavier than the section wants, I'm glad to reduce this to a single bullet in *Further links* instead. Following @ccf311's request in #156 for a proposed format — this is that proposal, in the smallest form I could make it useful.
