### PR TITLE
docs: fix two typos in General Controls oversight limitations section

### DIFF
--- a/content/ai_exchange/content/docs/1_general_controls.md
+++ b/content/ai_exchange/content/docs/1_general_controls.md
@@ -642,11 +642,11 @@ Classify agent actions by **risk tier** before deployment and assign oversight r
 The properties of wanted or unwanted model behavior often cannot be entirely specified, limiting the effectiveness of guardrails.
 
 **Limitations of human oversight:**
-The downsides of human oversight aare:
+The downsides of human oversight are:
 1. More costly and slower
 2. The risk of 'approval fatigue' where humans are overwhelmed by approval requests, especially if the large majority of those are okay.
 3. Lack of expertise to judge
-4. Lack of involvement in the situation to make the judgement - which is a form of lack of expertis
+4. Lack of involvement in the situation to make the judgement - which is a form of lack of expertise
 
 Ad.4: Regarding lack of involvement: for human operators or drivers of automated systems like self-driving cars, staying actively involved or having a role in the control loop helps maintain situational awareness. This involvement can prevent complacency and ensures that the human operator is ready to take over control if the automated system fails or encounters a scenario it cannot handle. However, maintaining situational awareness can be challenging with high levels of automation due to the "out-of-the-loop" phenomenon, where the human operator may become disengaged from the task at hand, leading to slower response times or decreased effectiveness in managing unexpected situations.
 In other words: If you as a user are not involved actively in performing a task, then you lose understanding of whether it is correct or what the impact can be. If you then only need to confirm something by saying 'go ahead' or 'cancel', a badly informed 'go ahead' is easy to pick.

--- a/content/ai_exchange/content/docs/ai_security_overview.md
+++ b/content/ai_exchange/content/docs/ai_security_overview.md
@@ -522,7 +522,7 @@ Clickable version, based on the [Periodic table](/go/periodictable/):
 <tr><td>Development - Supply chain</td><td><a href="/go/supplymodelpoison/">Supply-chain model poisoning</a></td></tr>
 <tr><td rowspan="3">Training data Confidentiality</td><td rowspan="2">Runtime - Model use</td><td><a href="/go/disclosureinoutput/">Disclosure in output</a></td></tr>
 <tr><td><a href="/go/modelinversionandmembership/">Model inversion / Membership inference</a></td></tr>
-<tr><td>Development - Engineering environment</td><td><a href="/go/devdataleak/">Developmen-time data leak</a></td></tr>
+<tr><td>Development - Engineering environment</td><td><a href="/go/devdataleak/">Development-time data leak</a></td></tr>
 <tr><td rowspan="3">Model confidentiality</td><td>Runtime - Model use</td><td><a href="/go/modelexfiltration/">Model exfiltration</a> (input-output harvesting)</td></tr>
 <tr><td>Runtime - Break into deployed model</td><td><a href="/go/runtimemodelleak/">Direct runtime model leak</a></td></tr>
 <tr><td>Development - Engineering environment</td><td><a href="/go/devmodelleak/">Direct development-time model-leak</a></td></tr>


### PR DESCRIPTION
Fixed two typos in the "Limitations of human oversight" subsection of the #OVERSIGHT control:
- "aare" corrected to "are"
- "expertis" corrected to "expertise"