### PR TITLE
Embed document outline bookmarks in the generated PDF

### DIFF
--- a/e2e/run.js
+++ b/e2e/run.js
@@ -454,9 +454,12 @@ async function testPdfOutline() {
 
   const printHtmlPath = path.join(__dirname, '../scripts/print.html');
   const printDom = new JSDOM(fs.readFileSync(printHtmlPath, 'utf-8'));
-  const headingCount = printDom.window.document.querySelectorAll(
-    '#content h1, #content h2, #content h3, #content h4, #content h5'
-  ).length;
+  const headings = [
+    ...printDom.window.document.querySelectorAll(
+      '#content h1, #content h2, #content h3, #content h4, #content h5'
+    ),
+  ].map((h) => h.textContent.replace(/\s+/g, ' ').trim());
+  const headingCount = headings.length;
   if (headingCount === 0) throw new Error('No headings found in print.html');
 
   const pdfPath = path.join(__dirname, '../content/ai_exchange/public/OWASP-AI-Exchange.pdf');
@@ -502,6 +505,13 @@ async function testPdfOutline() {
   }
   if (!titles.includes('Table of Contents')) {
     throw new Error('Expected "Table of Contents" bookmark is missing');
+  }
+  const titleSet = new Set(titles.map((t) => t.replace(/\s+/g, ' ').trim()));
+  const missingTitles = headings.filter((h) => !titleSet.has(h));
+  if (missingTitles.length > 0) {
+    throw new Error(
+      `${missingTitles.length} heading(s) missing from outline titles, e.g. "${missingTitles[0]}"`
+    );
   }
 }
 

--- a/e2e/run.js
+++ b/e2e/run.js
@@ -444,6 +444,67 @@ function testPdfBuild() {
   if (stat.size < 10000) throw new Error(`PDF too small: ${stat.size} bytes`);
 }
 
+// Independent check of the generated artifact for issue #149: the PDF must
+// embed an outline (bookmarks) tree that PDF readers show as a navigation
+// sidebar. Coverage is measured against the headings in the assembled
+// print.html, so the expectation follows the content instead of a fixed count.
+async function testPdfOutline() {
+  const { PDFArray, PDFDict, PDFDocument, PDFName } = require('pdf-lib');
+  const { JSDOM } = require('jsdom');
+
+  const printHtmlPath = path.join(__dirname, '../scripts/print.html');
+  const printDom = new JSDOM(fs.readFileSync(printHtmlPath, 'utf-8'));
+  const headingCount = printDom.window.document.querySelectorAll(
+    '#content h1, #content h2, #content h3, #content h4, #content h5'
+  ).length;
+  if (headingCount === 0) throw new Error('No headings found in print.html');
+
+  const pdfPath = path.join(__dirname, '../content/ai_exchange/public/OWASP-AI-Exchange.pdf');
+  const pdfDoc = await PDFDocument.load(fs.readFileSync(pdfPath));
+  const pageRefs = new Set(pdfDoc.getPages().map((p) => p.ref.toString()));
+  const outlinesRef = pdfDoc.catalog.get(PDFName.of('Outlines'));
+  if (!outlinesRef) throw new Error('PDF catalog has no /Outlines entry');
+  const outlines = pdfDoc.context.lookup(outlinesRef, PDFDict);
+
+  let entries = 0;
+  let maxDepth = 0;
+  let brokenDestinations = 0;
+  const titles = [];
+  const walk = (dict, depth) => {
+    let itemRef = dict.get(PDFName.of('First'));
+    while (itemRef) {
+      const item = pdfDoc.context.lookup(itemRef, PDFDict);
+      entries++;
+      maxDepth = Math.max(maxDepth, depth);
+      const title = item.get(PDFName.of('Title'));
+      titles.push(title && title.decodeText ? title.decodeText() : '');
+      let dest = item.get(PDFName.of('Dest'));
+      if (!dest) {
+        const actionRef = item.get(PDFName.of('A'));
+        if (actionRef) dest = pdfDoc.context.lookup(actionRef, PDFDict).get(PDFName.of('D'));
+      }
+      const destArray = dest ? pdfDoc.context.lookup(dest) : null;
+      if (!(destArray instanceof PDFArray) || destArray.size() === 0 || !pageRefs.has(destArray.get(0).toString())) {
+        brokenDestinations++;
+      }
+      walk(item, depth + 1);
+      itemRef = item.get(PDFName.of('Next'));
+    }
+  };
+  walk(outlines, 1);
+
+  if (entries < headingCount) {
+    throw new Error(`Outline has ${entries} bookmarks for ${headingCount} headings`);
+  }
+  if (maxDepth < 2) throw new Error(`Outline hierarchy is flat: ${maxDepth} level(s)`);
+  if (brokenDestinations > 0) {
+    throw new Error(`${brokenDestinations} bookmark(s) do not resolve to a page`);
+  }
+  if (!titles.includes('Table of Contents')) {
+    throw new Error('Expected "Table of Contents" bookmark is missing');
+  }
+}
+
 // --- Runner ---
 
 async function main() {
@@ -491,6 +552,9 @@ async function main() {
   });
 
   await run('18. PDF build succeeds', () => testPdfBuild());
+  await run('19. PDF outline bookmarks present and resolve (issue #149)', () =>
+    testPdfOutline()
+  );
 
   stopServer();
 

--- a/scripts/generate-pdf.js
+++ b/scripts/generate-pdf.js
@@ -3,7 +3,7 @@ const http = require('http');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 const puppeteer = require('puppeteer');
-const { PDFDocument } = require('pdf-lib');
+const { PDFArray, PDFDict, PDFDocument, PDFName } = require('pdf-lib');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 const SITE_DIR = path.join(PROJECT_ROOT, 'content/ai_exchange/public');
@@ -78,6 +78,68 @@ function assertContentParity(printHtmlPath) {
     throw new Error(`Content parity failed: website has ${totalWebsiteTables} tables, PDF has ${printTables}`);
   }
   console.log(`Content parity OK: ${printImages.size} images, ${printTables} tables`);
+}
+
+// Verify the shipped PDF carries a document outline (bookmarks): the tree must
+// exist, cover at least the headings collected for the visible TOC, keep a
+// hierarchy of two or more levels, and every entry must point at a page that is
+// present in the document. Runs on the final bytes, after the pdf-lib metadata
+// pass, so it also proves that pass preserved the outline Chromium generated.
+async function assertDocumentOutline(pdfPath, minEntries) {
+  const pdfDoc = await PDFDocument.load(fs.readFileSync(pdfPath));
+  const pageRefs = new Set(pdfDoc.getPages().map((p) => p.ref.toString()));
+  const outlinesRef = pdfDoc.catalog.get(PDFName.of('Outlines'));
+  if (!outlinesRef) {
+    throw new Error('Document outline missing: PDF catalog has no /Outlines entry.');
+  }
+  const outlines = pdfDoc.context.lookup(outlinesRef, PDFDict);
+
+  const resolvesToPage = (item) => {
+    let dest = item.get(PDFName.of('Dest'));
+    if (!dest) {
+      const actionRef = item.get(PDFName.of('A'));
+      if (!actionRef) return false;
+      dest = pdfDoc.context.lookup(actionRef, PDFDict).get(PDFName.of('D'));
+    }
+    if (!dest) return false;
+    const destArray = pdfDoc.context.lookup(dest);
+    if (!(destArray instanceof PDFArray) || destArray.size() === 0) return false;
+    return pageRefs.has(destArray.get(0).toString());
+  };
+
+  let entries = 0;
+  let maxDepth = 0;
+  const broken = [];
+  const walk = (dict, depth) => {
+    let itemRef = dict.get(PDFName.of('First'));
+    while (itemRef) {
+      const item = pdfDoc.context.lookup(itemRef, PDFDict);
+      entries++;
+      maxDepth = Math.max(maxDepth, depth);
+      const title = item.get(PDFName.of('Title'));
+      const titleText = title && title.decodeText ? title.decodeText() : '';
+      if (!title) {
+        broken.push(`bookmark ${entries}: missing /Title`);
+      } else if (!resolvesToPage(item)) {
+        broken.push(`bookmark ${entries} ("${titleText}"): destination does not resolve to a page`);
+      }
+      walk(item, depth + 1);
+      itemRef = item.get(PDFName.of('Next'));
+    }
+  };
+  walk(outlines, 1);
+
+  if (broken.length > 0) {
+    broken.forEach((b) => console.error(`  ${b}`));
+    throw new Error(`Document outline invalid: ${broken.length} bookmark(s) with missing titles or unresolvable destinations.`);
+  }
+  if (entries < minEntries) {
+    throw new Error(`Document outline incomplete: ${entries} bookmarks for ${minEntries} headings.`);
+  }
+  if (maxDepth < 2) {
+    throw new Error(`Document outline is flat: expected a hierarchy of at least 2 levels, got ${maxDepth}.`);
+  }
+  console.log(`Document outline OK: ${entries} bookmarks, ${maxDepth} levels deep`);
 }
 
 function resolveImagePath(urlPath) {
@@ -446,7 +508,10 @@ async function main() {
         headerTemplate: '<div></div>',
         footerTemplate: `<div style="width: 100%; font-size: 10px; text-align: center; color: #777;"><span class="pageNumber"></span> / <span class="totalPages"></span></div>`,
         printBackground: true,
-        generateDocumentOutline: true,
+        // Puppeteer's option is `outline`; it maps to Chromium's
+        // Page.printToPDF generateDocumentOutline parameter. Passing the CDP
+        // name directly is silently ignored and produces a PDF without bookmarks.
+        outline: true,
         tagged: true
     });
     await browser.close();
@@ -461,6 +526,8 @@ async function main() {
     pdfDoc.setProducer('OWASP AI Exchange');
     const modifiedPdfBytes = await pdfDoc.save();
     fs.writeFileSync(pdfPath, modifiedPdfBytes);
+
+    await assertDocumentOutline(pdfPath, tocList.querySelectorAll('li').length);
 
     console.log(`PDF saved to ${pdfPath}`);
     console.log('PDF generation complete.');

--- a/scripts/generate-pdf.js
+++ b/scripts/generate-pdf.js
@@ -3,7 +3,7 @@ const http = require('http');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 const puppeteer = require('puppeteer');
-const { PDFArray, PDFDict, PDFDocument, PDFName } = require('pdf-lib');
+const { PDFArray, PDFDict, PDFDocument, PDFHexString, PDFName } = require('pdf-lib');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 const SITE_DIR = path.join(PROJECT_ROOT, 'content/ai_exchange/public');
@@ -78,6 +78,44 @@ function assertContentParity(printHtmlPath) {
     throw new Error(`Content parity failed: website has ${totalWebsiteTables} tables, PDF has ${printTables}`);
   }
   console.log(`Content parity OK: ${printImages.size} images, ${printTables} tables`);
+}
+
+// Chromium assembles bookmark titles from layout lines and can drop the space
+// at a line-wrap boundary (e.g. "…you can dowith AI"). Where a title matches a
+// collected heading except for lost whitespace, restore the heading text.
+// Returns the number of titles repaired.
+function repairOutlineTitles(pdfDoc, headingTitles) {
+  const byCollapsedText = new Map();
+  for (const title of headingTitles) {
+    const key = title.replace(/\s+/g, '');
+    if (byCollapsedText.has(key) && byCollapsedText.get(key) !== title) {
+      byCollapsedText.set(key, null); // ambiguous; leave such titles alone
+    } else {
+      byCollapsedText.set(key, title);
+    }
+  }
+  const outlinesRef = pdfDoc.catalog.get(PDFName.of('Outlines'));
+  if (!outlinesRef) return 0;
+  let repaired = 0;
+  const walk = (dict) => {
+    let itemRef = dict.get(PDFName.of('First'));
+    while (itemRef) {
+      const item = pdfDoc.context.lookup(itemRef, PDFDict);
+      const title = item.get(PDFName.of('Title'));
+      const text = title && title.decodeText ? title.decodeText() : null;
+      if (text) {
+        const canonical = byCollapsedText.get(text.replace(/\s+/g, ''));
+        if (canonical && canonical !== text) {
+          item.set(PDFName.of('Title'), PDFHexString.fromText(canonical));
+          repaired++;
+        }
+      }
+      walk(item);
+      itemRef = item.get(PDFName.of('Next'));
+    }
+  };
+  walk(pdfDoc.context.lookup(outlinesRef, PDFDict));
+  return repaired;
 }
 
 // Verify the shipped PDF carries a document outline (bookmarks): the tree must
@@ -295,6 +333,8 @@ async function main() {
     explicitPageBreak.style.pageBreakBefore = 'always';
     contentDiv.appendChild(explicitPageBreak);
 
+    const headingTitles = [];
+
     console.log('Processing pages...');
     for (const pagePath of PAGES) {
       const fullPath = path.join(SITE_DIR, pagePath);
@@ -323,6 +363,7 @@ async function main() {
         a.textContent = h.textContent.trim();
         li.appendChild(a);
         tocList.appendChild(li);
+        headingTitles.push(h.textContent.replace(/\s+/g, ' ').trim());
       });
 
       // Resolve and validate image paths before appending; fail if any local image is missing
@@ -524,6 +565,10 @@ async function main() {
     pdfDoc.setKeywords(['AI security', 'AI privacy', 'OWASP', 'threats', 'controls', 'machine learning', 'LLM']);
     pdfDoc.setCreator('OWASP AI Exchange');
     pdfDoc.setProducer('OWASP AI Exchange');
+    const repairedTitles = repairOutlineTitles(pdfDoc, headingTitles);
+    if (repairedTitles > 0) {
+      console.log(`Restored whitespace in ${repairedTitles} bookmark title(s)`);
+    }
     const modifiedPdfBytes = await pdfDoc.save();
     fs.writeFileSync(pdfPath, modifiedPdfBytes);
 


### PR DESCRIPTION
## Summary
- fix the Puppeteer `page.pdf` option name so Chromium actually generates the document outline: the script passed the raw CDP parameter name `generateDocumentOutline`, which Puppeteer silently ignores; the supported option is `outline`
- restore the whitespace Chromium drops from bookmark titles at line-wrap boundaries (one heading came out as "…you can dowith AI"): during the existing pdf-lib metadata pass, any title that differs from a collected heading only by lost whitespace is replaced with the canonical heading text
- verify the shipped PDF at the end of `generate-pdf.js`, after the pdf-lib pass: the outline tree must exist, cover at least all headings collected for the visible TOC, keep a hierarchy of two or more levels, and every bookmark must resolve to a page present in the document
- add an independent e2e check (`19. PDF outline bookmarks present and resolve`) that parses the generated artifact, measures outline coverage against the headings in the assembled `print.html`, and requires every heading to appear verbatim among the bookmark titles

## Why
The currently published `OWASP-AI-Exchange.pdf` (363 pages) has no `/Outlines` entry in its catalog, so PDF readers show no navigation sidebar. The intent was already in the script — the flag simply never reached Chromium because of the option name. This closes the gap and locks it in with deterministic validation so a future refactor cannot silently drop the bookmarks again (the failure mode that caused this issue).

Closes #149.

## Result
- 220 bookmarks, 4 hierarchy levels, mirroring the heading structure (`0. AI Security Overview`, `1. General controls`, … `Index` at the top level)
- 220 of 220 bookmark destinations resolve, in monotonically increasing page order matching the document flow (verified independently with pypdf in addition to the in-script pdf-lib assertion)
- all 218 TOC headings appear verbatim as bookmark titles (218/218 after the whitespace restoration; 217/218 before it)
- works with the pinned `chrome-headless-shell` used by CI, and the outline survives the pdf-lib metadata step

## Validation
- `npm test` — 20/20 OpenCRE enrichment tests passed
- `npm run build:site` && `npm run pagefind`
- `npm run build:pdf` — prints `Restored whitespace in 1 bookmark title(s)` and `Document outline OK: 220 bookmarks, 4 levels deep`; the build now fails if bookmarks are missing, incomplete, flat, or unresolvable
- `npm run test:e2e` — tests 18 and the new 19 pass; tests 1, 2, and 17 (search highlighting) fail identically on unmodified `main` in my environment, so they are unrelated to this change
- `git diff --check` is clean