### PR TITLE
Unify PDF outline validation and lighten the deploy check

### DIFF
--- a/e2e/run.js
+++ b/e2e/run.js
@@ -444,12 +444,16 @@ function testPdfBuild() {
   if (stat.size < 10000) throw new Error(`PDF too small: ${stat.size} bytes`);
 }
 
-// Independent check of the generated artifact for issue #149: the PDF must
+// Independent check of the shipped artifact for issue #149: the PDF must
 // embed an outline (bookmarks) tree that PDF readers show as a navigation
-// sidebar. Coverage is measured against the headings in the assembled
-// print.html, so the expectation follows the content instead of a fixed count.
+// sidebar. This is the heavier companion to the in-memory assert inside
+// generate-pdf.js — it re-parses the file from disk and measures coverage
+// against the headings in the assembled print.html, so the expectation
+// follows the content instead of a fixed count. Traversal comes from the
+// shared scripts/pdf-outline helper (issue #198).
 async function testPdfOutline() {
-  const { PDFArray, PDFDict, PDFDocument, PDFName } = require('pdf-lib');
+  const { PDFDocument } = require('pdf-lib');
+  const { collectOutline } = require('../scripts/pdf-outline');
   const { JSDOM } = require('jsdom');
 
   const printHtmlPath = path.join(__dirname, '../scripts/print.html');
@@ -464,40 +468,15 @@ async function testPdfOutline() {
 
   const pdfPath = path.join(__dirname, '../content/ai_exchange/public/OWASP-AI-Exchange.pdf');
   const pdfDoc = await PDFDocument.load(fs.readFileSync(pdfPath));
-  const pageRefs = new Set(pdfDoc.getPages().map((p) => p.ref.toString()));
-  const outlinesRef = pdfDoc.catalog.get(PDFName.of('Outlines'));
-  if (!outlinesRef) throw new Error('PDF catalog has no /Outlines entry');
-  const outlines = pdfDoc.context.lookup(outlinesRef, PDFDict);
+  const entries = collectOutline(pdfDoc);
+  if (!entries) throw new Error('PDF catalog has no /Outlines entry');
 
-  let entries = 0;
-  let maxDepth = 0;
-  let brokenDestinations = 0;
-  const titles = [];
-  const walk = (dict, depth) => {
-    let itemRef = dict.get(PDFName.of('First'));
-    while (itemRef) {
-      const item = pdfDoc.context.lookup(itemRef, PDFDict);
-      entries++;
-      maxDepth = Math.max(maxDepth, depth);
-      const title = item.get(PDFName.of('Title'));
-      titles.push(title && title.decodeText ? title.decodeText() : '');
-      let dest = item.get(PDFName.of('Dest'));
-      if (!dest) {
-        const actionRef = item.get(PDFName.of('A'));
-        if (actionRef) dest = pdfDoc.context.lookup(actionRef, PDFDict).get(PDFName.of('D'));
-      }
-      const destArray = dest ? pdfDoc.context.lookup(dest) : null;
-      if (!(destArray instanceof PDFArray) || destArray.size() === 0 || !pageRefs.has(destArray.get(0).toString())) {
-        brokenDestinations++;
-      }
-      walk(item, depth + 1);
-      itemRef = item.get(PDFName.of('Next'));
-    }
-  };
-  walk(outlines, 1);
+  const maxDepth = entries.reduce((max, e) => Math.max(max, e.depth), 0);
+  const brokenDestinations = entries.filter((e) => !e.resolvesToPage).length;
+  const titles = entries.map((e) => e.title || '');
 
-  if (entries < headingCount) {
-    throw new Error(`Outline has ${entries} bookmarks for ${headingCount} headings`);
+  if (entries.length < headingCount) {
+    throw new Error(`Outline has ${entries.length} bookmarks for ${headingCount} headings`);
   }
   if (maxDepth < 2) throw new Error(`Outline hierarchy is flat: ${maxDepth} level(s)`);
   if (brokenDestinations > 0) {

--- a/scripts/generate-pdf.js
+++ b/scripts/generate-pdf.js
@@ -3,7 +3,8 @@ const http = require('http');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 const puppeteer = require('puppeteer');
-const { PDFArray, PDFDict, PDFDocument, PDFHexString, PDFName } = require('pdf-lib');
+const { PDFDocument, PDFHexString, PDFName } = require('pdf-lib');
+const { collectOutline } = require('./pdf-outline');
 
 const PROJECT_ROOT = path.join(__dirname, '..');
 const SITE_DIR = path.join(PROJECT_ROOT, 'content/ai_exchange/public');
@@ -94,90 +95,55 @@ function repairOutlineTitles(pdfDoc, headingTitles) {
       byCollapsedText.set(key, title);
     }
   }
-  const outlinesRef = pdfDoc.catalog.get(PDFName.of('Outlines'));
-  if (!outlinesRef) return 0;
+  const entries = collectOutline(pdfDoc);
+  if (!entries) return 0;
   let repaired = 0;
-  const walk = (dict) => {
-    let itemRef = dict.get(PDFName.of('First'));
-    while (itemRef) {
-      const item = pdfDoc.context.lookup(itemRef, PDFDict);
-      const title = item.get(PDFName.of('Title'));
-      const text = title && title.decodeText ? title.decodeText() : null;
-      if (text) {
-        const canonical = byCollapsedText.get(text.replace(/\s+/g, ''));
-        if (canonical && canonical !== text) {
-          item.set(PDFName.of('Title'), PDFHexString.fromText(canonical));
-          repaired++;
-        }
-      }
-      walk(item);
-      itemRef = item.get(PDFName.of('Next'));
+  for (const { item, title } of entries) {
+    if (!title) continue;
+    const canonical = byCollapsedText.get(title.replace(/\s+/g, ''));
+    if (canonical && canonical !== title) {
+      item.set(PDFName.of('Title'), PDFHexString.fromText(canonical));
+      repaired++;
     }
-  };
-  walk(pdfDoc.context.lookup(outlinesRef, PDFDict));
+  }
   return repaired;
 }
 
-// Verify the shipped PDF carries a document outline (bookmarks): the tree must
-// exist, cover at least the headings collected for the visible TOC, keep a
-// hierarchy of two or more levels, and every entry must point at a page that is
-// present in the document. Runs on the final bytes, after the pdf-lib metadata
-// pass, so it also proves that pass preserved the outline Chromium generated.
-async function assertDocumentOutline(pdfPath, minEntries) {
-  const pdfDoc = await PDFDocument.load(fs.readFileSync(pdfPath));
-  const pageRefs = new Set(pdfDoc.getPages().map((p) => p.ref.toString()));
-  const outlinesRef = pdfDoc.catalog.get(PDFName.of('Outlines'));
-  if (!outlinesRef) {
+// Deploy-path outline check: the tree must exist, cover at least the headings
+// collected for the visible TOC, keep a hierarchy of two or more levels, and
+// every entry must point at a page present in the document. Runs on the
+// in-memory document after the title repair, so the deploy path pays no
+// second full-PDF parse for validation and a broken outline aborts the build
+// before the final artifact is written. The e2e suite additionally re-parses
+// the shipped file from disk and checks verbatim heading coverage.
+function assertDocumentOutline(pdfDoc, minEntries) {
+  const entries = collectOutline(pdfDoc);
+  if (!entries) {
     throw new Error('Document outline missing: PDF catalog has no /Outlines entry.');
   }
-  const outlines = pdfDoc.context.lookup(outlinesRef, PDFDict);
 
-  const resolvesToPage = (item) => {
-    let dest = item.get(PDFName.of('Dest'));
-    if (!dest) {
-      const actionRef = item.get(PDFName.of('A'));
-      if (!actionRef) return false;
-      dest = pdfDoc.context.lookup(actionRef, PDFDict).get(PDFName.of('D'));
-    }
-    if (!dest) return false;
-    const destArray = pdfDoc.context.lookup(dest);
-    if (!(destArray instanceof PDFArray) || destArray.size() === 0) return false;
-    return pageRefs.has(destArray.get(0).toString());
-  };
-
-  let entries = 0;
-  let maxDepth = 0;
   const broken = [];
-  const walk = (dict, depth) => {
-    let itemRef = dict.get(PDFName.of('First'));
-    while (itemRef) {
-      const item = pdfDoc.context.lookup(itemRef, PDFDict);
-      entries++;
-      maxDepth = Math.max(maxDepth, depth);
-      const title = item.get(PDFName.of('Title'));
-      const titleText = title && title.decodeText ? title.decodeText() : '';
-      if (!title) {
-        broken.push(`bookmark ${entries}: missing /Title`);
-      } else if (!resolvesToPage(item)) {
-        broken.push(`bookmark ${entries} ("${titleText}"): destination does not resolve to a page`);
-      }
-      walk(item, depth + 1);
-      itemRef = item.get(PDFName.of('Next'));
+  let maxDepth = 0;
+  entries.forEach(({ depth, title, resolvesToPage }, index) => {
+    maxDepth = Math.max(maxDepth, depth);
+    if (title === null) {
+      broken.push(`bookmark ${index + 1}: missing /Title`);
+    } else if (!resolvesToPage) {
+      broken.push(`bookmark ${index + 1} ("${title}"): destination does not resolve to a page`);
     }
-  };
-  walk(outlines, 1);
+  });
 
   if (broken.length > 0) {
     broken.forEach((b) => console.error(`  ${b}`));
     throw new Error(`Document outline invalid: ${broken.length} bookmark(s) with missing titles or unresolvable destinations.`);
   }
-  if (entries < minEntries) {
-    throw new Error(`Document outline incomplete: ${entries} bookmarks for ${minEntries} headings.`);
+  if (entries.length < minEntries) {
+    throw new Error(`Document outline incomplete: ${entries.length} bookmarks for ${minEntries} headings.`);
   }
   if (maxDepth < 2) {
     throw new Error(`Document outline is flat: expected a hierarchy of at least 2 levels, got ${maxDepth}.`);
   }
-  console.log(`Document outline OK: ${entries} bookmarks, ${maxDepth} levels deep`);
+  console.log(`Document outline OK: ${entries.length} bookmarks, ${maxDepth} levels deep`);
 }
 
 function resolveImagePath(urlPath) {
@@ -569,10 +535,9 @@ async function main() {
     if (repairedTitles > 0) {
       console.log(`Restored whitespace in ${repairedTitles} bookmark title(s)`);
     }
+    assertDocumentOutline(pdfDoc, tocList.querySelectorAll('li').length);
     const modifiedPdfBytes = await pdfDoc.save();
     fs.writeFileSync(pdfPath, modifiedPdfBytes);
-
-    await assertDocumentOutline(pdfPath, tocList.querySelectorAll('li').length);
 
     console.log(`PDF saved to ${pdfPath}`);
     console.log('PDF generation complete.');

--- a/scripts/pdf-outline.js
+++ b/scripts/pdf-outline.js
@@ -1,0 +1,71 @@
+const { PDFArray, PDFDict, PDFName } = require('pdf-lib');
+
+// Shared reader for the document outline (bookmarks) tree of a PDF loaded with
+// pdf-lib. The build script (assert + title repair) and the e2e suite all need
+// the same First/Next traversal; keeping it here stops the copies drifting
+// apart (issue #198).
+
+// Depth-first walk over the outline tree in document order, starting at depth
+// 1. Calls visit(item, depth) with each bookmark item dictionary. Returns
+// false without visiting anything when the PDF has no outline. Throws on a
+// malformed tree that revisits an item, instead of looping forever.
+function walkOutline(pdfDoc, visit) {
+  const outlinesRef = pdfDoc.catalog.get(PDFName.of('Outlines'));
+  if (!outlinesRef) return false;
+  const seen = new Set();
+  const walk = (dict, depth) => {
+    let itemRef = dict.get(PDFName.of('First'));
+    while (itemRef) {
+      const tag = itemRef.toString();
+      if (seen.has(tag)) {
+        throw new Error(`Document outline is malformed: item ${tag} appears twice in the tree.`);
+      }
+      seen.add(tag);
+      const item = pdfDoc.context.lookup(itemRef, PDFDict);
+      visit(item, depth);
+      walk(item, depth + 1);
+      itemRef = item.get(PDFName.of('Next'));
+    }
+  };
+  walk(pdfDoc.context.lookup(outlinesRef, PDFDict), 1);
+  return true;
+}
+
+function itemTitle(item) {
+  const title = item.get(PDFName.of('Title'));
+  return title && title.decodeText ? title.decodeText() : null;
+}
+
+// A bookmark points either at a /Dest array directly or through a /A GoTo
+// action; either way the first element must reference a page in the document.
+function itemResolvesToPage(pdfDoc, pageRefs, item) {
+  let dest = item.get(PDFName.of('Dest'));
+  if (!dest) {
+    const actionRef = item.get(PDFName.of('A'));
+    if (!actionRef) return false;
+    dest = pdfDoc.context.lookup(actionRef, PDFDict).get(PDFName.of('D'));
+  }
+  if (!dest) return false;
+  const destArray = pdfDoc.context.lookup(dest);
+  if (!(destArray instanceof PDFArray) || destArray.size() === 0) return false;
+  return pageRefs.has(destArray.get(0).toString());
+}
+
+// Flatten the outline into [{item, depth, title, resolvesToPage}] in document
+// order, or null when the PDF has no outline. `item` is the live pdf-lib
+// dictionary, so callers may mutate entries (e.g. rewrite a /Title).
+function collectOutline(pdfDoc) {
+  const pageRefs = new Set(pdfDoc.getPages().map((p) => p.ref.toString()));
+  const entries = [];
+  const hasOutline = walkOutline(pdfDoc, (item, depth) => {
+    entries.push({
+      item,
+      depth,
+      title: itemTitle(item),
+      resolvesToPage: itemResolvesToPage(pdfDoc, pageRefs, item),
+    });
+  });
+  return hasOutline ? entries : null;
+}
+
+module.exports = { collectOutline };


### PR DESCRIPTION
## Summary
Follow-up to #197, addressing @northdpole's review note and the acceptance criteria in #198:

- extract the shared First/Next outline traversal into `scripts/pdf-outline.js`; the build assert, the bookmark-title repair, and the e2e check now all consume the same `collectOutline` helper instead of three hand-rolled walkers
- add a revisit guard to the traversal, so a malformed outline tree fails with a clear error instead of recursing forever (the optional criterion in #198)
- lighten the deploy-path check: `assertDocumentOutline` now validates the in-memory document after the pdf-lib metadata pass instead of re-parsing the written file, and runs before the final artifact is written
- keep the fuller check where it was: e2e test 19 still independently re-parses the shipped file from disk and requires verbatim heading coverage plus the "Table of Contents" bookmark

## Why
The three walkers duplicated the same traversal and were easy to drift apart. On the deploy path, re-parsing the just-written artifact cost a second full-PDF parse per build for information already available in memory: on the current 13.35 MB artifact, `PDFDocument.load` takes ~440 ms while the outline walk itself takes ~2 ms. Validating the loaded document keeps the fail-closed guarantee (a broken outline still aborts the build, now before the final artifact is written) at effectively zero added deploy cost.

On the "is e2e on the deploy path" question from #198: it is not — `deploy.yml` and `pr_deploy.yml` only run `npm run build:pdf`, and `e2e/run.js` is documented as manual-only. So no deploy runs the PDF build twice today; this PR keeps it that way and leaves the heavy verification in e2e.

Closes #198.

## Result
Behavior is unchanged where it matters — the refactored pipeline produces byte-identical validation outcomes on current content:

- `npm run build:pdf` still reports `Restored whitespace in 1 bookmark title(s)` and `Document outline OK: 220 bookmarks, 4 levels deep`
- independent pypdf verification of the shipped artifact: 220 bookmarks, max depth 4, destinations in monotonically increasing page order, repaired title intact

## Validation
- `npm test` — 20/20 OpenCRE enrichment tests passed
- `npm run build:site` && `npm run pagefind`
- `npm run build:pdf` — passes with the in-memory assert
- `npm run test:e2e` — tests 18 and 19 pass; tests 1, 2, and 17 (search highlighting) fail identically on unmodified `main` in my environment, unrelated to this change
- `git diff --check` is clean