### PR TITLE
Direct augmentation data leak: name embedding inversion and its incident-classification impact

### DIFF
--- a/content/ai_exchange/content/docs/4_runtime_application_security_threats.md
+++ b/content/ai_exchange/content/docs/4_runtime_application_security_threats.md
@@ -196,7 +196,7 @@ Impact: Confidentiality breach of sensitive augmentation data through a conventi
 
 Augmentation data (ad hoc retrieved information inserted into a prompt, such as system prompts, or documents), needs to be transfered and stored - for example for Retrieval Augmented Generation typically in _vector databases_. This increases the attack surface for any sensitive data, since it's stored outside its regular storage with the regular protection (e.g., company document archive) and therefore requires additional protection.   
 
-So-called _vectors_ that form a representation of augmentation data are typically vulnerable for extracting information and should therefore be included in protection.
+So-called _vectors_ that form a representation of augmentation data are typically vulnerable for extracting information and should therefore be included in protection. The extraction technique is _embedding inversion_: reconstructing source text from stored vectors. Reported recovery ranges from about 50-70% of the words in sentence embeddings up to 92% exact reconstruction of short inputs, and more recent work performs this zero-shot against a black-box encoder, without training a model for the target encoder. Defenses such as adding noise to stored embeddings reduce recovery but trade off retrieval quality and do not fully prevent it. This matters for incident classification: an exposed vector store is often rated low severity because "only the embeddings leaked" while the source documents sit encrypted elsewhere. If the vectors are invertible that rating is wrong, the source text should be treated as exposed, and under regimes such as GDPR Article 33 that changes the breach notification assessment.
 
 Alternative ways for augmentation data to leak are:
 - [input data leak](/go/inputdataleak)
@@ -210,6 +210,8 @@ Alternative ways for augmentation data to leak are:
     - [NIST AI 100-2: sec. 3.2.2: Poisoning Attacks](https://csrc.nist.gov/pubs/ai/100/2/e2023/final)
 <!-- OPENCRE_SECTION_CRE_END slug=augmentationdataleak -->
 - [Mitigating Security Risks in RAG LLM Applications, November 2023, CSA](https://cloudsecurityalliance.org/blog/2023/11/22/mitigating-security-risks-in-retrieval-augmented-generation-rag-llm-applications)
+- [Text Embeddings Reveal (Almost) As Much As Text, Morris et al., EMNLP 2023](https://arxiv.org/abs/2310.06816)
+- [Universal Zero-shot Embedding Inversion, Zhang et al., 2025](https://arxiv.org/abs/2504.00147)
 
 **Controls**
 - See [General controls](/go/generalcontrols)
@@ -220,7 +222,7 @@ Alternative ways for augmentation data to leak are:
 > Permalink: https://owaspai.org/go/augmentationdataconfidentiality
 
 **Description**  
-See the [security program](/go/secprogram) and [application security](/go/secdevprogram), [development environment security](/go/devsecurity), and [data segregation](/go/segregatedata) to protect the confidentiality of transporting and storing augmentation data (e.g., access control, encryption, minimize retention).
+See the [security program](/go/secprogram) and [application security](/go/secdevprogram), [development environment security](/go/devsecurity), and [data segregation](/go/segregatedata) to protect the confidentiality of transporting and storing augmentation data (e.g., access control, encryption, minimize retention). Because stored vectors can be inverted to recover source text (see 4.6), hold vector database backups at the sensitivity tier of the source documents, and treat embeddings sent to a third-party embedding service as a transfer of the underlying data.
 
 
 


### PR DESCRIPTION
Closes #205.

The "direct augmentation data leak" section (4.6) says stored vectors are "vulnerable for extracting information" but never names the technique or says how much can actually be recovered. This adds that.

What changed in `4_runtime_application_security_threats.md`:

- Names the technique: embedding inversion, reconstructing source text from stored vectors.
- Gives the recovery range from the literature: from roughly half to two-thirds of the words in sentence embeddings, up to 92% exact reconstruction of 32-token inputs (Morris et al.), and recent work does this zero-shot against a black-box encoder without training a model for the target.
- Notes the defense tradeoff: adding noise to stored embeddings lowers recovery but costs retrieval quality and does not fully prevent it.
- Adds the incident-classification point: an exposed vector store is often rated low severity because "only the embeddings leaked." If those vectors are invertible, the source text should be treated as exposed, which changes the breach assessment under regimes such as GDPR Article 33.
- Adds a control: hold vector database backups at the sensitivity tier of the source documents, and treat embeddings sent to a third-party embedding service as a transfer of the underlying data.

Two references added:
- Text Embeddings Reveal (Almost) As Much As Text, Morris et al., EMNLP 2023 (arxiv 2310.06816)
- Universal Zero-shot Embedding Inversion, Zhang et al., 2025 (arxiv 2504.00147)

Four lines added, two changed. No structural changes to the section.