### PR TITLE
Add RAG systems overview (threat model) and RAG system security testing

### DIFF
--- a/content/ai_exchange/content/docs/5_testing.md
+++ b/content/ai_exchange/content/docs/5_testing.md
@@ -79,6 +79,7 @@ Agentic testing extends the general approach above — same lifecycle steps, but
 - Threat-model the agentic system before testing: enumerate agents, orchestrators, tools, data sources, trust boundaries, and every external input surface (user input, retrieved documents, tool outputs, inter-agent messages).
 - Confirm designed controls work under **normal** conditions before adversarial load — untested baselines cannot be distinguished from controls that fail under attack.
 - Test [prompt injection](/go/promptinjection/) on each external surface; run **single-turn and multi-turn** sequences separately — single-turn resistance does not predict session-level degradation (_crescendo_ patterns).
+- Where the agent retrieves external data before acting (RAG), test that path using [RAG system security testing](/go/ragtesting/) — retrieval is a second input channel with its own authorization surface, distinct from tool-call validation.
 - Test tool-call validation **independently of the LLM** by sending crafted invocations directly to the access-control or API gateway layer. Controls that exist only in a system prompt are not enforced against injection.
 - Exercise failure modes: context-window saturation, tool errors, partial task completion, and unexpected orchestrator routing.
 - Define minimum coverage criteria up front — which layers (reasoning, tool execution, infrastructure, inter-agent communication) were tested, to what depth, and with what corpus size. **Report untested threat categories explicitly**; coverage gaps are findings.
@@ -107,6 +108,52 @@ Scope agentic pen tests across:
 4. **Inter-agent communication layer** — message tampering, identity spoofing, trust-boundary exploitation ([agent message structure manipulation](/go/agentmessagestructuremanipulation/)).
 
 Prioritise findings with an agentic-aware severity model: autonomous execution scope, persistence across sessions, multi-agent propagation potential, and irreversibility of impact.
+
+### RAG system security testing
+>Category: discussion  
+>Permalink: https://owaspai.org/go/ragtesting/
+
+RAG testing extends the general approach above — same lifecycle steps, but with a second input channel (retrieval) that most single-prompt test suites don't exercise, and a corpus that has its own integrity and access-control surface independent of the model.
+
+**Methodologies (coverage-driven testing)**
+
+- Threat-model the RAG pipeline before testing: enumerate every ingestion source, the indexing/chunking/embedding process, the retriever and any re-ranker, and the authorization model that's supposed to govern which chunks a given user/session can retrieve. Map each to the [RAG systems overview](/go/ragoverview/).
+- Test the **retrieval channel separately from the chat/query channel**: inject a test payload into a document, ingest it through the real pipeline (not by hand-crafting the prompt), and confirm it surfaces through retrieval before testing whether the model acts on it — this isolates ingestion/indexing failures from generation failures.
+- Test **retrieval-scope enforcement directly against the index/retriever**, independent of the LLM: query the vector store or search index with credentials for different users/tenants and confirm chunk-level access control matches the source system's ACLs. A retriever that returns unauthorized chunks fails this test even if the model later "declines" to use them — the data has already left the trust boundary. See also [disclosure in output](/go/disclosureinoutput/).
+- Test **indirect prompt injection via the retrieval path specifically**: place attack payloads (see the [prompt injection test procedure](/go/testingpromptinjection/)) inside documents likely to be retrieved for realistic queries, not just in a document guaranteed to rank first — low-relevance placement should also be tested, since re-rankers and hybrid search can surface unexpected chunks.
+- Test **corpus poisoning** by introducing edited or newly added documents through the same access an attacker would realistically have (a wiki edit, a shared-drive upload, a ticket comment, a crawled page) and checking whether biased or attacker-controlled content measurably shifts retrieved results and generated output.
+- Test **metadata and provenance trust**: attempt to forge source, timestamp, author, or confidence fields associated with a chunk, and check whether the system (or its prompt template) grants that content more trust than an unlabelled or low-provenance chunk.
+- Test **embedding confidentiality**: with direct read access to the vector store (simulating a compromised database credential or backup), attempt to reconstruct source text from stored embedding vectors. This is independent of model-facing tests — it targets the vector store as a data-at-rest asset, not the inference API.
+- Exercise **staleness and cache behavior**: confirm that deleting, correcting, or access-restricting a source document actually removes or restricts it from the index and from any retrieval cache, not just from the original source.
+- Test **rendering and downstream handling of retrieved content** in the output — links, Markdown, HTML, code blocks — for [output injection](/go/outputcontainsconventionalinjection/), especially where output is rendered in a browser or another automated consumer.
+- Combine with **conventional testing** of the ingestion and retrieval infrastructure itself — the vector store API, search endpoints, and any document-parsing step (PDF/Office parsers, OCR) are ordinary application attack surface (SSRF, deserialization, path traversal, injection) independent of the model.
+- Define minimum coverage up front — which corpus sources, retrieval configurations, and authorization boundaries were tested, and at what scale. **Report untested sources or boundaries explicitly**; an untested ingestion path is a finding, not an assumption of safety.
+
+**Red teaming exercises**
+
+- **Cross-tenant/cross-permission retrieval**: as a low-privilege identity, attempt to retrieve or induce disclosure of content scoped to a higher-privilege identity or another tenant, through both direct queries and indirect injection.
+- **Corpus-to-action chaining**: where the system can trigger actions (see Agentic AI security testing above), test whether a payload planted in a retrievable document can reach a tool call — this is the RAG instance of the [lethal trifecta](/go/agenticaioverview/).
+- **Ingestion-path fuzzing**: submit malformed, oversized, or adversarially structured documents through every available ingestion route (upload, connector sync, crawl) and observe both availability impact and parser-level exploitation.
+- **Provenance spoofing at scale**: systematically vary source/author/confidence metadata across a batch of test documents to measure how much influence forged provenance has on retrieval ranking and on the model's apparent trust in the content.
+
+Teams need both retrieval/search engineering expertise and offensive-security expertise — many RAG failures are pipeline/configuration issues (broken ACL propagation, unfiltered document parsers, unbounded ingestion) rather than model behavior issues, and won't be caught by prompt-only red teaming.
+
+**Penetration testing (layer model)**
+
+Scope RAG pen tests across:
+
+1. **Ingestion layer** — source connector authentication, parser exploitation (PDF/Office/HTML), malicious file handling, ingestion-triggered SSRF.
+2. **Indexing layer** — embedding pipeline integrity, chunking manipulation, index write-access control, cache/staleness handling.
+3. **Retrieval layer** — query-time authorization enforcement, cross-tenant isolation, ranking/relevance manipulation, retrieval-scope bypass.
+4. **Augmentation/prompt-assembly layer** — how retrieved chunks are delimited, labelled, and inserted into the prompt; whether the template distinguishes trusted instructions from retrieved content (see [input segregation](/go/inputsegregation/)).
+5. **Generation/output layer** — indirect prompt injection success, sensitive-data disclosure, output-injection into downstream renderers.
+
+Prioritise findings by: authorization impact (does this cross a trust boundary), corpus scale (does it affect one document or a shared source), and — where the RAG system feeds an agent — downstream action potential, using the agentic severity model above.
+
+**References**
+- [OWASP Cheat Sheet: RAG Security](https://cheatsheetseries.owasp.org/cheatsheets/RAG_Security_Cheat_Sheet.html)
+- [OWASP AI Testing Guide](https://owasp.org/www-project-ai-testing-guide/)
+- See [prompt injection testing](/go/testingpromptinjection/) above for payload construction and detection pairing — reused directly for the retrieval-channel tests here.
 
 ### Testing against Prompt injection
 > Category: AI security test  

--- a/content/ai_exchange/content/docs/ai_security_overview.md
+++ b/content/ai_exchange/content/docs/ai_security_overview.md
@@ -502,6 +502,62 @@ Further links:
 - [Microsoft Pulse report on Agentic security](https://www.microsoft.com/en-us/security/security-insider/emerging-trends/cyber-pulse-ai-security-report)
 
 
+### RAG systems overview
+>Category: discussion  
+>Permalink: https://owaspai.org/go/ragoverview/
+
+Retrieval-Augmented Generation (RAG) systems retrieve external data at inference time and insert it into the model's input to ground its output. This is the most common form of **augmentation data** discussed throughout the Exchange, alongside system prompts and agent memory — see the augmentation-data branch of the [threat model](/go/threatmodel/).
+
+A typical RAG pipeline has five stages, each with a distinct trust boundary:
+1. **Ingestion**: source documents (files, wikis, tickets, web pages, emails) are collected.
+2. **Indexing**: documents are chunked, embedded, and stored in a vector store or search index.
+3. **Retrieval**: a query (often derived from user input) is used to fetch the top-matching chunks.
+4. **Augmentation**: retrieved chunks are inserted into the model's prompt.
+5. **Generation**: the model produces output based on the augmented prompt.
+
+RAG is not a separate threat landscape — the same asset/impact model applies (see the [threats overview](/go/threatsoverview/) and [AI security matrix](/go/aisecuritymatrix/)). This section highlights where RAG concentrates existing threats, and where it introduces attack surface that a plain chatbot or single-document-in-context system doesn't have.
+
+**Why RAG changes the picture**
+- The **corpus itself becomes an asset** with its own confidentiality, integrity and availability requirements — often larger, less curated, and more frequently updated than training data, and often assembled from many contributors with different trust levels.
+- **Retrieval is a second, mostly invisible input channel.** The user only sees their own query; the model also sees whatever the retriever selected. Any content that can enter the index — a shared drive, a ticketing system, a public wiki, a crawled web page — is a potential attack surface, whether or not the current user could reach it directly.
+- **Access control and retrieval scope frequently diverge.** The vector store rarely enforces the same per-document ACLs as the source system it was built from, which creates a confused-deputy pattern: the model (and by extension the user) can end up retrieving chunks the user was never authorized to see.
+
+**Key threats to consider, mapped to existing threat categories**
+- **[Indirect prompt injection](/go/indirectpromptinjection/)**: an attacker plants instructions in a document that later gets ingested, indexed, and retrieved into another user's prompt — the classic RAG attack. Reachability depends only on getting content into the corpus, not on querying the system directly. This is the most consequential RAG-specific instance of prompt injection.
+- **[Data poisoning](/go/datapoison/) of the retrieval corpus**: an attacker with write access to a source (or to the crawl/ingestion pipeline) inserts or edits documents to bias what gets retrieved and surfaced as "fact" — closer to a persistent integrity attack on the corpus than a one-off injection.
+- **[Augmentation data manipulation](/go/augmentationdatamanipulation/)**: broader than poisoning — includes manipulating chunking, embeddings, or metadata (e.g., forging a source field or timestamp) to change what gets retrieved or how much the model trusts it, without touching the underlying document.
+- **Augmentation data leak / [disclosure in output](/go/disclosureinoutput/)**: retrieval crossing an authorization boundary — cross-tenant leakage, retrieval of documents the querying user lacks permission for, or an attacker crafting queries to enumerate corpus contents (membership-inference-style probing of the index rather than the model).
+- **[Model input confidentiality](/go/modelinputconfidentiality/) / retrieval-log exposure**: queries and retrieved chunks are often logged for debugging or evaluation; those logs can themselves leak sensitive corpus or query content if not protected to the same standard as the corpus itself.
+- **Embedding inversion**: an attacker with direct access to the vector store (not the model API) can attempt to reconstruct the original text from a stored embedding vector. This is mechanically distinct from [model inversion and membership inference](/go/modelinversionandmembership/) — that threat reconstructs training data through iterative query optimization against the model; embedding inversion requires no model queries at all, only read access to the stored vectors, making the vector store itself a direct confidentiality target independent of the model.
+- **[Output contains conventional injection](/go/outputcontainsconventionalinjection/)**: retrieved content carrying markup, scripts, or malicious links that get echoed into the model's output and rendered downstream (XSS, Markdown-based exfiltration links, etc.) — the RAG-specific path into this existing threat.
+- **[AI resource exhaustion](/go/airesourceexhaustion/)**: oversized or adversarially crafted documents at ingestion time, or queries engineered to force expensive retrieval/re-ranking, degrading availability.
+- **[Supply chain](/go/supplychainmanage/)**: third-party or externally hosted embedding models, vector-store services, and ingestion connectors extend the RAG trust boundary to those suppliers.
+- **Vector index integrity**: the index is a distinct asset from the corpus — an attacker who can write to it directly (misconfigured or default-open vector database, over-privileged ingestion service) can change what gets retrieved without touching a single source document. Treat unauthorized index writes as an integrity threat in its own right, not just a downstream effect of corpus poisoning.
+- **Missing or forgeable source attribution**: if a RAG response doesn't carry verifiable provenance (which chunks, from which documents, with what hash), there's no way to detect after the fact whether a poisoned or stale document influenced an answer — this turns an otherwise detectable [data poisoning](/go/datapoison/) incident into an undetectable one.
+- **Unsafe fallback on component failure**: if retrieval, an access-control check, or hash verification fails and the system falls back to answering from model memory alone, filtering nothing, or serving a stale cached response, every control above this point in the pipeline is silently bypassed. This is an availability/integrity trade-off attackers can deliberately trigger by forcing failures.
+- **Incomplete data deletion propagation**: deleting or de-permissioning a source document doesn't automatically remove its chunks, embeddings, or cached responses — an "authorized deletion" that isn't cascaded leaves the same data reachable through the retriever, which is both a [disclosure](/go/disclosureinoutput/) risk and, where regulated data is involved, a compliance failure.
+
+**The lethal trifecta, applied to RAG**
+
+RAG is frequently the "data" leg of the [lethal trifecta](/go/agenticaioverview/) described in the Agentic AI overview: attacker-influenced data reaching the model (via indirect prompt injection through a retrieved chunk), access to sensitive data (the corpus itself, or other documents reachable through the same retriever), and an ability to send data out (an agent action, or an exfiltration channel embedded in the output). A RAG system doesn't need to be "agentic" in the action-triggering sense for this to matter — read access to a sensitive corpus plus an output channel a user can observe (e.g., a rendered link) is enough.
+
+**Threat-model questions specific to RAG** (extending the decision tree in [risk analysis](/go/threatmodel/)):
+- Does your system insert retrieved data into the model's input? → consider [indirect prompt injection](/go/indirectpromptinjection/) and [augmentation data manipulation](/go/augmentationdatamanipulation/).
+- Can anyone other than trusted engineers add, edit, or influence documents that end up in the corpus (shared drives, tickets, web crawls, user uploads)? → consider [data poisoning](/go/datapoison/) of the corpus, and treat the ingestion pipeline itself as a threat surface.
+- Does retrieval scope match the source documents' access control, per user/session? → if not, consider augmentation data leak via authorization mismatch — see [disclosure in output](/go/disclosureinoutput/).
+- Is the corpus, embedding model, or vector-store service provided by a third party? → apply [supply chain management](/go/supplychainmanage/).
+- Can retrieved content reach a rendering context (browser, chat UI with Markdown/HTML) or a downstream action? → consider [output contains conventional injection](/go/outputcontainsconventionalinjection/) and, if the system can act on retrieved content, cross-reference the [Agentic AI overview](/go/agenticaioverview/).
+- Does anything other than the ingestion pipeline have write access to the vector index? → consider vector index integrity as a distinct threat from corpus poisoning.
+- Do responses carry verifiable source attribution (which chunks, which documents, with what hash)? → if not, a poisoning or staleness incident may be undetectable after the fact.
+- What does the system do when retrieval, an access-control check, or hash verification fails? → if it falls back to unfiltered or cached behavior, every upstream control can be bypassed by deliberately triggering that failure.
+- When a source document is deleted or de-permissioned, is that propagated to its chunks, embeddings, and cached responses? → an uncascaded deletion leaves the data reachable through the retriever.
+
+**Controls**: the [periodic table of AI security](/go/periodictable/) already lists the applicable controls per threat above; no RAG-specific control category is needed beyond applying [augmentation data confidentiality/integrity](/go/augmentationdataintegrity/) and [input segregation](/go/inputsegregation/) specifically to the retrieval channel, treating the corpus with the same rigor as [training data](/go/datapoison/) — access-controlled, versioned, and attributable — and applying fail-closed defaults at every pipeline stage rather than only at the model boundary.
+
+For the full threat and control picture, see the [threats overview](/go/threatsoverview/) and the [periodic table](/go/periodictable/).  
+This section highlights RAG-specific attention points only — not a separate threat landscape.
+
+
 ### AI Security Matrix
 >Category: discussion  
 >Permalink: https://owaspai.org/go/aisecuritymatrix/

--- a/content/ai_exchange/firebase.json
+++ b/content/ai_exchange/firebase.json
@@ -104,6 +104,11 @@
         "type": 302
       },  
       {
+        "source": "/go/ragoverview/",
+        "destination": "/docs/ai_security_overview/#rag-systems-overview",
+        "type": 302
+      },  
+      {
         "source": "/goto/aisecuritymatrix/",
         "destination": "/docs/ai_security_overview/#ai-security-matrix",
         "type": 302
@@ -1066,6 +1071,11 @@
       {
         "source": "/go/testingpromptinjection/",
         "destination": "/docs/5_testing/#testing-against-prompt-injection",
+        "type": 302
+      },
+      {
+        "source": "/go/ragtesting/",
+        "destination": "/docs/5_testing/#rag-system-security-testing",
         "type": 302
       },
       {


### PR DESCRIPTION
Relates to discussion #193.

## Summary

Adds two new subsections, as agreed in #193:

1. **"RAG systems overview"**: new subsection under Threats overview in `ai_security_overview.md`, placed as a sibling to Agentic AI overview (same heading level, inserted right after it, before AI Security Matrix).
2. **"RAG system security testing"**: new subsection under section 5 in `5_testing.md`, placed as a sibling to (not nested under) Agentic AI security testing, inserted immediately below it and before Testing against Prompt injection.

Also includes:

- A minimal amendment to the existing Agentic AI security testing section: one cross-reference bullet under Methodologies, pointing to RAG testing for agents that retrieve before they act.
- Two new permalink entries in `content/ai_exchange/firebase.json`: `/go/ragoverview/` and `/go/ragtesting/`, following the exact pattern of the existing `/go/agenticaioverview/` and `/go/testingpromptinjection/` entries.

## Approach

RAG maps onto the existing augmentation-data threat model. Every threat links to an existing permalink, so the draft introduces no new taxonomy or threat IDs. The overview extends the decision-tree style used in `/go/threatmodel/` with RAG-specific questions and cross-references the lethal trifecta from the Agentic AI overview.

The testing section follows the same structure as Agentic AI security testing (Methodologies / Red teaming exercises / Penetration testing layer model), adapted to a 5-layer RAG pipeline (ingestion / indexing / retrieval / augmentation / generation).

## Cross-checked against

Checked against two independent sources before opening this PR:

- **OWASP Cheat Sheet Series — RAG Security Cheat Sheet**: added four threats/controls not in the initial draft — vector index integrity, source attribution/provenance, fail-closed design on component failure, and data-deletion propagation (cascading deletion when a source document is removed).
- **OWASP AI Testing Guide** (AITG-APP-08 and related tests): added embedding inversion as a distinct threat/test; both the cheat sheet and the Testing Guide flagged this as a gap in the initial draft. Also confirmed model/training-level poisoning (AITG-MOD-02, AITG-INF-05) is a distinct threat class from RAG corpus poisoning, so the two stay separate.

No Testing Guide content was copied; it was used only to validate coverage. Every permalink in the draft already exists in `firebase.json`.

## Not included (flagging separately)

While cross-checking the tool-review tables in section 5, none of the reviewed tools (PyRIT, Garak, Promptfoo) could be confirmed to test retrieval-scope enforcement directly against a vector store/index (querying with different tenant identities and comparing chunk-level access control to the source ACL). Promptfoo has RAG-specific and access-control plugins, but they operate through the model/application interface, not directly against the index. This goes in a separate issue per #193, not in this PR.

## Checklist

- [x] New content only extends existing threat/control permalinks, no new taxonomy
- [x] Every `/go/` link verified against `content/ai_exchange/firebase.json`
- [x] Heading levels and formatting match surrounding sections
- [x] New `/go/` permalinks added to `content/ai_exchange/firebase.json`
- [x] `git apply --check` verified clean before commit
- [ ] Awaiting maintainer review on placement / wording

cc @robvanderveer