### PR TITLE
Expand evasion testing with adaptive attacks and evaluation diagnostics

### DIFF
--- a/content/ai_exchange/content/docs/5_testing.md
+++ b/content/ai_exchange/content/docs/5_testing.md
@@ -248,6 +248,8 @@ Resistance to [evasion attacks](/go/evasion), is tested by looking for feasible 
 2. whether the AI system can limit or stop the search for such inputs, for example through rate limiting or detection;
 3. whether surrogate models can be created and used to prepare the attack.
 
+NOTE: This procedure targets predictive AI models such as classifiers, object detectors, and regression models. Generative AI models can be evaded too, for example through adversarial suffixes optimized against the model's safety alignment, or through perturbed images that steer a vision-language model's text output. That work overlaps with [prompt injection testing](/go/testingpromptinjection/) but relies on optimization rather than crafted instructions. Teams running safety-critical generative AI should decide whether it needs testing alongside prompt injection testing.
+
 #### Test procedure
 See the [section above](/go/testing) for the general steps in AI security testing.  
 The steps specific for testing against this threat are:
@@ -258,33 +260,55 @@ Establish criteria for deciding whether evasion inputs are feasible. These crite
 a) whether evasion inputs can bypass input-focused mitigations, such as anomaly detection, human oversight, or automated oversight. These controls may limit how much evasion inputs may differ from normal inputs. This difference is expressed through a perturbation limit, which can be defined in ways such as:
 - norm-based limits such as L0, L2, or L-infinity;
 - perceptual similarity measures such as SSIM or PSNR for images, audio, and video;
-- domain-specific rules, such as thresholds for pixel changes or decibel limits for audio.
+- domain-specific rules, such as thresholds for pixel changes or decibel limits for audio;
+- semantic limits for text, such as embedding similarity, edit distance, or a requirement that the text stays grammatical;
+- feature constraints for tabular data, such as value ranges, allowed categories, and rules that keep fields consistent with each other.
   
 b) whether attackers could reasonably create the evasion inputs, considering how input data is collected and processed. Feasibility criteria need to take environmental factors into account, including lighting, noise, interference, and timing.
 
 EXAMPLE: If the AI system receives images directly from a low-resolution camera, an attacker has limited ability to make precise, small modifications to the input.
 
-**(2) Perform searches for succesful evasion**  
+EXAMPLE: Where input passes through a camera or microphone before it reaches the model, the environment often destroys the perturbation. Downsampling and sensor noise wipe out fine pixel-level changes, and JPEG compression discards much of the high-frequency detail that a digital attack depends on. Attackers work around this by optimizing the input across a range of simulated conditions, such as varying brightness, blur, and angle, so that the result survives capture. Tests of physical-world scenarios need the same approach; without it, a passing result may only show that the capture path degraded the input.
+
+**(2) Perform searches for successful evasion**  
+Before choosing attack methods, write down the threat model the test represents: what the attacker knows about the model (parameters, architecture, or output only), how they reach it (a local copy, an API, or an application in front of it), whether they control the exact digital input or have to work through a camera or microphone, whether they want one specific wrong output or any wrong output, which perturbation limit and budget apply from step 1, how many queries they can afford, whether they know which defenses are deployed, and whether the attack happens at inference time or earlier in the lifecycle. Each attack in the test then follows from these choices, so a reviewer can see why it was run and why others were left out.
+
 Search for effective evasion inputs, meaning inputs that satisfy the feasibility criteria and would have unacceptable impact severity:
 -  When relevant, perform a **perfect-knowledge attack** using the target model's parameters. Use state-of-the-art tools to search for evasion inputs, starting from known inputs that produce correct outputs. Keep changes within the perturbation limit derived from the feasibility criteria. Perform both diffuse and localized searches, where localized changes are feasible. For localized changes, the allowed perturbation may typically be higher or absent. A perfect-knowledge attack is relevant when attacker has complete access to model parameters (typically, when the attacker is able to leverage the parameters for gradient calculations). Otherwise, this attack type may be skipped. The search needs to include both in-distribution and out-of-distribution inputs, such as known samples from all classes and samples that do not belong to any class in a classification task.
 - When needed, perform a **zero-knowledge attack** by following the previous procedure but allowing the tooling to use only the model output, not the model parameters, while iteratively adapting the inputs. This step is not required if the previous step already found a feasible evasion input with unacceptable results.
+- When the system returns class labels without confidence scores, perform a **decision-based attack**. These attacks locate the decision boundary and estimate a search direction from the labels alone, which makes them the only option when scores are withheld as a defense. HopSkipJump is a current example. This step is not required if earlier steps already found a feasible evasion input with unacceptable results.
 - When possible and needed, perform a **transfer attack** using surrogate models. Follow the procedure of the first step but search against the surrogate model. This is possible if the attacker can find or create a model with the same or a similar task. The surrogate may be a commercial or open-source model, or a new model trained on task data that the attacker can obtain or create, depending on the attacker profile. This step is not required if earlier steps already found a feasible evasion input with unacceptable results.
-- When possible and needed, perform a **heuristic attack** on the model. This applies when domain knowledge and understanding of the intended use suggest that certain changes may produce the desired effect. For example, testers may check whether an image of a red balloon on a sidewalk is classified as a stop sign. This step is not required if earlier steps already found a feasible evasion input with unacceptable results.
+- When possible and needed, perform a **heuristic attack** on the model, also called domain-informed or manual adversarial testing. This applies when domain knowledge and understanding of the intended use suggest that certain changes may produce the desired effect. For example, testers may check whether an image of a red balloon on a sidewalk is classified as a stop sign. Unlike the categories above, it draws on domain expertise rather than an optimization algorithm. This step is not required if earlier steps already found a feasible evasion input with unacceptable results.
 
 
 The search continues while the effort remains within the maximum effort that the relevant attacker profile would be able and willing to spend. If feasible evasion inputs are found that cause unacceptable impact severity on the target model in the AI system, the test fails. Additional mitigations then need to be implemented and the test needs to be repeated until successful.
 
+**Adaptive attacks**  
+Where the system has defenses in place, such as input preprocessing, detection, randomization, or adversarial training, run the search against the defense rather than around it. When an off-the-shelf attack fails on a defended model, that result shows only that the attack as configured did not work. Tramèr et al. took thirteen defenses published at ICLR, ICML, and NeurIPS and broke all thirteen once each attack was tailored to the defense in front of it, and concluded that this tailoring cannot be automated.
 
-EXAMPLE: Known methods for searching adversarial examples at the time of writing include Square Attack for zero-knowledge search and Projected Gradient Descent for perfect-knowledge search.
+Two things follow. First, use a strong standardized baseline instead of one attack with hand-picked settings. AutoAttack is the common choice: it runs Auto-PGD under cross-entropy loss, Auto-PGD under Difference of Logits Ratio loss, the Fast Adaptive Boundary attack, and the black-box Square Attack, and it needs no hyperparameter tuning. The Difference of Logits Ratio loss keeps a usable gradient where cross-entropy saturates on a confident model, and the Fast Adaptive Boundary attack reports how far away the nearest decision boundary is rather than only whether a fixed budget was enough. Second, treat that baseline as a floor. Where a specific defense is deployed, add an attack built against it, for example by replacing a non-differentiable preprocessing step with a differentiable approximation (Backward Pass Differentiable Approximation), or by averaging gradients over the randomness that a randomized defense introduces (Expectation over Transformation).
+
+NOTE: Gradient-based searches such as PGD and Auto-PGD can fail for the wrong reason. Some defenses break the gradient signal instead of the underlying weakness, which is known as gradient masking or obfuscated gradients. Athalye et al. found this in 7 of the 9 white-box defenses published at ICLR 2018. Three checks detect it:
+- **Black-box against white-box.** A white-box attack has strictly more information, so it should do at least as well as a black-box one. If Square Attack or HopSkipJump beats a tuned Auto-PGD, the gradient is masked.
+- **Budget monotonicity.** Raising the perturbation budget should raise the attack success rate. If the rate flattens early or drops, the defense has distorted the loss landscape rather than removed the vulnerability.
+- **Random noise baseline.** If the model resists a gradient-based search but random uniform noise within the same budget flips it, the reported resistance is not real.
+
+Where any of these checks indicates masking, fall back on gradient-free searches, a differentiable approximation of the blocking step, or a transfer attack from a surrogate model.
+
+EXAMPLE: Known methods for searching adversarial examples at the time of writing include Auto-PGD and the Fast Adaptive Boundary attack for perfect-knowledge search, Square Attack for zero-knowledge search, and HopSkipJump where only labels are returned. AutoAttack bundles the first three with Square Attack into a single evaluation. These are available through several of the tools in our [test tools section](/go/testingtoolspredictiveai/), including ART and Foolbox.
+
+NOTE: These attacks assume a continuous input space with an Lp perturbation limit, which in practice mostly means images. Other input types need their own methods. Text needs search over token substitutions, character edits, or optimized suffixes, as implemented in tools such as TextAttack. For tabular models the search has to respect feature ranges, allowed categories, and consistency between fields. Audio attacks perturb the waveform, usually within a bound set by what a listener will not notice. What carries across is the approach rather than the algorithm: let the search adapt instead of fixing its settings up front, keep a gradient-free method in reserve, and pick the strongest method available for the input type rather than the most familiar one.
+
+NOTE: Attacks serve different purposes. Single-step methods such as FGSM are cheap and useful for regression checks and for seeing how a model behaves, but they do not support a claim about resistance. Auto-PGD carries the main assessment, the Fast Adaptive Boundary attack measures how much margin the model has, gradient-free methods such as Square Attack check whether the gradient is being masked, and defense-specific attacks test whether a deployed defense holds. Base conclusions on the strongest applicable attacks.
 
 EXAMPLE: Heuristic changes can include replacing words with synonyms or typos, changing text encoding, or applying image transformations such as scaling or rotation.
 
 EXAMPLE: A possible test scenario is: the tester does not perform a perfect-knowledge search on the target model because it is very unlikely that the attacker can steal the non-public model. The tester then tries a zero-knowledge search on the target model and does not succeed. Some adversarial samples are found, but most are not feasible inputs; where they are feasible, the misclassification is harmless. The tester then tries transfer attacks with a surrogate model. No existing model is available for the similar task of estimating a horse's age from an image, but a database of horse images with ages is available. Risk analysis shows that the relevant attacker profile includes an experienced machine learning expert with several days available, so the tester trains a surrogate model on that database. The tester uses Projected Gradient Descent on the surrogate and finds several evasion inputs. Some of these inputs also cause wrong outputs in the target model. One would cause unacceptable harm. The conclusion is that the AI system fails the evasion-resistance test because an attacker could train a model copy and use it to prepare harmful evasion inputs.
 
-**(3) Separate feasiblity tests**  
+**(3) Separate feasibility tests**  
 Where feasibility is uncertain, perform separate feasibility tests to determine whether the criteria are met. Such tests may check whether existing detection mechanisms would block a particular evasion input, or whether an attacker could create the input in a real-world situation.
 
-Tools for state-of-the-art testing are usually available for the relevant problem space, see our [test tools section](go/testingtoolspredictiveai/).
+Tools for state-of-the-art testing are usually available for the relevant problem space, see our [test tools section](/go/testingtoolspredictiveai/).
 
 NOTE: These tools often rely on curated implementations of published adversarial AI attacks. They will not necessarily protect against zero-day attack algorithms.
 
@@ -294,8 +318,28 @@ If the test identifies feasible evasion attack inputs that would have unacceptab
 
 NOTE Depending on the intended use, a single evasion input may be enough to cause unacceptable impact severity. In other cases, a series or class of evasion attacks may be needed to reach that level of impact.
 
+Where the context calls for numbers, report robust accuracy (accuracy on adversarial inputs at a stated perturbation budget) and attack success rate, and record for each attack what was run and under what conditions: the algorithm, the threat model, the samples used, whether the goal was targeted or untargeted, the norm and budget, the query budget for black-box attacks, and the effect on accuracy for benign inputs. Systems defended with randomized smoothing can also report the certified radius, the L2 distance within which the smoothed model's prediction provably cannot change. Figures of this kind let teams compare model versions, weigh one defense against another, and run the check in a build pipeline. [RobustBench](https://robustbench.github.io/) publishes reference protocols and leaderboards for the common image benchmarks.
+
+NOTE: Where the model or a defense is non-deterministic, for example dropout at inference, randomized smoothing, or random input transformations, a single run says little, since the same attack may succeed or fail depending on the random draw. Repeat each configuration and report the spread rather than one figure, and have the attack optimize against the average behaviour across random draws rather than a single one.
+
 **Positive testing**  
 It is of course important to also test the AI system for correct behaviour in benign situations. Depending on context, such testing may be integrated in the implementation of the security test by using the same mechanisms. Such testing ideally includes the testing of detection mechanisms, to ensure that not too many false positives are triggered by benign inputs. Positive testing is essential to ensure that security mechanisms do not degrade intended functionality or user experience beyond acceptable levels.
+
+Adversarial training and certified defenses cost accuracy on benign inputs, so measure that cost and check it against what the use case can absorb. Fast single-step adversarial training carries a further risk: the model can learn to defeat the cheap attack it was trained on while staying open to iterative ones, a failure known as catastrophic overfitting. Re-run the full evaluation after any hardening step, because a defense that only changes which attack works has not improved resistance.
+
+**References**  
+- See below for the [test tools section](/go/testingtoolspredictiveai/)
+- [NIST AI 100-2e2025, Adversarial Machine Learning: A Taxonomy and Terminology of Attacks and Mitigations](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-2e2025.pdf)
+- [RobustBench](https://robustbench.github.io/) - standardized robustness benchmark and leaderboards
+- [AutoAttack](https://github.com/fra31/auto-attack) - Croce & Hein, "Reliable evaluation of adversarial robustness with an ensemble of diverse parameter-free attacks", ICML 2020
+- [Tramèr et al., "On Adaptive Attacks to Adversarial Example Defenses", NeurIPS 2020](https://arxiv.org/abs/2002.08347)
+- [Athalye et al., "Obfuscated Gradients Give a False Sense of Security", ICML 2018](https://arxiv.org/abs/1802.00420)
+- [Chen et al., "HopSkipJumpAttack: A Query-Efficient Decision-Based Attack", IEEE S&P 2020](https://arxiv.org/abs/1904.02144)
+- [Andriushchenko et al., "Square Attack: a query-efficient black-box adversarial attack via random search", ECCV 2020](https://arxiv.org/abs/1912.00049)
+- [Cohen et al., "Certified Adversarial Robustness via Randomized Smoothing", ICML 2019](https://arxiv.org/abs/1902.02918)
+- [Wong et al., "Fast is better than free: Revisiting adversarial training", ICLR 2020](https://arxiv.org/abs/2001.03994) - catastrophic overfitting
+- [Tsipras et al., "Robustness May Be at Odds with Accuracy", ICLR 2019](https://arxiv.org/abs/1805.12152)
+- [Zou et al., "Universal and Transferable Adversarial Attacks on Aligned Language Models", 2023](https://arxiv.org/abs/2307.15043)
 
 
 
@@ -600,6 +644,8 @@ Evasion:Tests model performance against adversarial inputs
 
 **Tool Name: DeepSec**
 
+NOTE: DEEPSEC is the reference implementation for the IEEE S&P 2019 paper by Ling et al. Its last commit was in May 2019 and it targets PyTorch 0.4, so it is best treated as a research artifact for reproducing that paper rather than a tool for current testing. ART and Foolbox cover the same attacks and are maintained.
+
 | **Tool Name: DeepSec** |  |
 | --- | --- |
 | Developer/ Source | Developed by a team of academic researchers in collaboration with the National University of Singapore. |
@@ -615,7 +661,7 @@ Evasion:Tests model performance against adversarial inputs
 |  | - **GitHub Forks:** ~70 |
 |  | - **Number of Issues:** ~15 open issues |
 |  | - **Trend:** Stable with a focus on deep learning security |
-| **Community Support** | - **Active Issues:** Currently has ongoing issues and updates, suggesting active maintenance. |
+| **Community Support** | - **Active Issues:** No commits since May 2019; open issues are unanswered. Treat as unmaintained. |
 |  | - **Documentation:** Available through GitHub, covering setup, use, and contributions. |
 |  | - **Discussion Forums:**  GitHub Discussions section and community channels support developer interactions. |
 |  | - **Contributors:**  A small but dedicated contributor base. |

--- a/content/ai_exchange/content/docs/5_testing.md
+++ b/content/ai_exchange/content/docs/5_testing.md
@@ -248,7 +248,7 @@ Resistance to [evasion attacks](/go/evasion), is tested by looking for feasible 
 2. whether the AI system can limit or stop the search for such inputs, for example through rate limiting or detection;
 3. whether surrogate models can be created and used to prepare the attack.
 
-NOTE: This procedure targets predictive AI models such as classifiers, object detectors, and regression models. Generative AI models can be evaded too, for example through adversarial suffixes optimized against the model's safety alignment, or through perturbed images that steer a vision-language model's text output. That work overlaps with [prompt injection testing](/go/testingpromptinjection/) but relies on optimization rather than crafted instructions. Teams running safety-critical generative AI should decide whether it needs testing alongside prompt injection testing.
+NOTE: This procedure targets predictive AI models such as classifiers, object detectors, and regression models. Generative AI models can be evaded too, for example through adversarial suffixes optimized against the model's safety alignment, or through perturbed images that steer a vision-language model's text output. That work overlaps with [prompt injection testing](/go/testingpromptinjection) but relies on optimization rather than crafted instructions. Teams running safety-critical generative AI should decide whether it needs testing alongside prompt injection testing.
 
 #### Test procedure
 See the [section above](/go/testing) for the general steps in AI security testing.  
@@ -286,7 +286,7 @@ The search continues while the effort remains within the maximum effort that the
 **Adaptive attacks**  
 Where the system has defenses in place, such as input preprocessing, detection, randomization, or adversarial training, run the search against the defense rather than around it. When an off-the-shelf attack fails on a defended model, that result shows only that the attack as configured did not work. Tramèr et al. took thirteen defenses published at ICLR, ICML, and NeurIPS and broke all thirteen once each attack was tailored to the defense in front of it, and concluded that this tailoring cannot be automated.
 
-Two things follow. First, use a strong standardized baseline instead of one attack with hand-picked settings. AutoAttack is the common choice: it runs Auto-PGD under cross-entropy loss, Auto-PGD under Difference of Logits Ratio loss, the Fast Adaptive Boundary attack, and the black-box Square Attack, and it needs no hyperparameter tuning. The Difference of Logits Ratio loss keeps a usable gradient where cross-entropy saturates on a confident model, and the Fast Adaptive Boundary attack reports how far away the nearest decision boundary is rather than only whether a fixed budget was enough. Second, treat that baseline as a floor. Where a specific defense is deployed, add an attack built against it, for example by replacing a non-differentiable preprocessing step with a differentiable approximation (Backward Pass Differentiable Approximation), or by averaging gradients over the randomness that a randomized defense introduces (Expectation over Transformation).
+Two things follow. First, use a strong standardized ensemble instead of one attack with hand-picked settings, and pick whichever ensemble is state of the art at the time of testing rather than the one named here. At the time of writing, [AutoAttack](https://github.com/fra31/auto-attack) is one such ensemble: it runs Auto-PGD under cross-entropy loss, Auto-PGD under Difference of Logits Ratio loss, the Fast Adaptive Boundary attack, and the black-box Square Attack, and it needs no hyperparameter tuning. The Difference of Logits Ratio loss keeps a usable gradient where cross-entropy saturates on a confident model, and the Fast Adaptive Boundary attack reports how far away the nearest decision boundary is rather than only whether a fixed budget was enough. Second, treat that baseline as a floor. Where a specific defense is deployed, add an attack built against it, for example by replacing a non-differentiable preprocessing step with a differentiable approximation (Backward Pass Differentiable Approximation), or by averaging gradients over the randomness that a randomized defense introduces (Expectation over Transformation).
 
 NOTE: Gradient-based searches such as PGD and Auto-PGD can fail for the wrong reason. Some defenses break the gradient signal instead of the underlying weakness, which is known as gradient masking or obfuscated gradients. Athalye et al. found this in 7 of the 9 white-box defenses published at ICLR 2018. Three checks detect it:
 - **Black-box against white-box.** A white-box attack has strictly more information, so it should do at least as well as a black-box one. If Square Attack or HopSkipJump beats a tuned Auto-PGD, the gradient is masked.
@@ -295,7 +295,7 @@ NOTE: Gradient-based searches such as PGD and Auto-PGD can fail for the wrong re
 
 Where any of these checks indicates masking, fall back on gradient-free searches, a differentiable approximation of the blocking step, or a transfer attack from a surrogate model.
 
-EXAMPLE: Known methods for searching adversarial examples at the time of writing include Auto-PGD and the Fast Adaptive Boundary attack for perfect-knowledge search, Square Attack for zero-knowledge search, and HopSkipJump where only labels are returned. AutoAttack bundles the first three with Square Attack into a single evaluation. These are available through several of the tools in our [test tools section](/go/testingtoolspredictiveai/), including ART and Foolbox.
+EXAMPLE: Known methods for searching adversarial examples at the time of writing include Auto-PGD and the Fast Adaptive Boundary attack for perfect-knowledge search, Square Attack for zero-knowledge search, and HopSkipJump where only labels are returned. AutoAttack bundles the first three with Square Attack into a single evaluation. These are available through several of the tools in our [test tools section](/go/testingtoolspredictiveai), including ART and Foolbox.
 
 NOTE: These attacks assume a continuous input space with an Lp perturbation limit, which in practice mostly means images. Other input types need their own methods. Text needs search over token substitutions, character edits, or optimized suffixes, as implemented in tools such as TextAttack. For tabular models the search has to respect feature ranges, allowed categories, and consistency between fields. Audio attacks perturb the waveform, usually within a bound set by what a listener will not notice. What carries across is the approach rather than the algorithm: let the search adapt instead of fixing its settings up front, keep a gradient-free method in reserve, and pick the strongest method available for the input type rather than the most familiar one.
 
@@ -308,7 +308,7 @@ EXAMPLE: A possible test scenario is: the tester does not perform a perfect-know
 **(3) Separate feasibility tests**  
 Where feasibility is uncertain, perform separate feasibility tests to determine whether the criteria are met. Such tests may check whether existing detection mechanisms would block a particular evasion input, or whether an attacker could create the input in a real-world situation.
 
-Tools for state-of-the-art testing are usually available for the relevant problem space, see our [test tools section](/go/testingtoolspredictiveai/).
+Tools for state-of-the-art testing are usually available for the relevant problem space, see our [test tools section](/go/testingtoolspredictiveai).
 
 NOTE: These tools often rely on curated implementations of published adversarial AI attacks. They will not necessarily protect against zero-day attack algorithms.
 
@@ -325,10 +325,10 @@ NOTE: Where the model or a defense is non-deterministic, for example dropout at 
 **Positive testing**  
 It is of course important to also test the AI system for correct behaviour in benign situations. Depending on context, such testing may be integrated in the implementation of the security test by using the same mechanisms. Such testing ideally includes the testing of detection mechanisms, to ensure that not too many false positives are triggered by benign inputs. Positive testing is essential to ensure that security mechanisms do not degrade intended functionality or user experience beyond acceptable levels.
 
-Adversarial training and certified defenses cost accuracy on benign inputs, so measure that cost and check it against what the use case can absorb. Fast single-step adversarial training carries a further risk: the model can learn to defeat the cheap attack it was trained on while staying open to iterative ones, a failure known as catastrophic overfitting. Re-run the full evaluation after any hardening step, because a defense that only changes which attack works has not improved resistance.
+Where the model has been hardened, for example with [adversarial training](/go/trainadversarial), positive testing should quantify what that hardening costs on benign inputs and confirm the loss stays within what the use case can absorb. Re-run the evasion test after any hardening change, because a defense that only changes which attack works has not improved resistance.
 
 **References**  
-- See below for the [test tools section](/go/testingtoolspredictiveai/)
+- See below for the [test tools section](/go/testingtoolspredictiveai)
 - [NIST AI 100-2e2025, Adversarial Machine Learning: A Taxonomy and Terminology of Attacks and Mitigations](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.100-2e2025.pdf)
 - [RobustBench](https://robustbench.github.io/) - standardized robustness benchmark and leaderboards
 - [AutoAttack](https://github.com/fra31/auto-attack) - Croce & Hein, "Reliable evaluation of adversarial robustness with an ensemble of diverse parameter-free attacks", ICML 2020
@@ -337,8 +337,6 @@ Adversarial training and certified defenses cost accuracy on benign inputs, so m
 - [Chen et al., "HopSkipJumpAttack: A Query-Efficient Decision-Based Attack", IEEE S&P 2020](https://arxiv.org/abs/1904.02144)
 - [Andriushchenko et al., "Square Attack: a query-efficient black-box adversarial attack via random search", ECCV 2020](https://arxiv.org/abs/1912.00049)
 - [Cohen et al., "Certified Adversarial Robustness via Randomized Smoothing", ICML 2019](https://arxiv.org/abs/1902.02918)
-- [Wong et al., "Fast is better than free: Revisiting adversarial training", ICLR 2020](https://arxiv.org/abs/2001.03994) - catastrophic overfitting
-- [Tsipras et al., "Robustness May Be at Odds with Accuracy", ICLR 2019](https://arxiv.org/abs/1805.12152)
 - [Zou et al., "Universal and Transferable Adversarial Attacks on Aligned Language Models", 2023](https://arxiv.org/abs/2307.15043)
 
 


### PR DESCRIPTION
## What this changes

The evasion testing procedure named vanilla PGD and Square Attack as its worked examples and stopped there. Two gaps followed. A tester running PGD against a defended model had nothing telling them the result may be an artifact of the defense breaking the gradient rather than evidence of resistance, and nothing pointing at the stronger standardized attacks that have been the reference baseline since 2020.

**Added**

- An **Adaptive attacks** block for defended models, plus a NOTE with three gradient-masking diagnostics: black-box beating white-box, non-monotonic response to budget increases, and random noise succeeding where a gradient search failed. Athalye et al. found masking in 7 of the 9 white-box defenses at ICLR 2018.
- A **threat model** paragraph opening step 2, so attack selection follows from attacker knowledge, access, input control, goal, perturbation budget, query budget and timing rather than being ad hoc.
- **Decision-based attacks** for APIs that return labels without confidence scores.
- Perturbation limits for **text and tabular** inputs, and an EXAMPLE of how cameras, sensor noise and JPEG compression destroy digital perturbations.
- A scope NOTE separating this procedure from GenAI evasion and prompt injection testing; a NOTE that the named attacks assume continuous inputs and what to use otherwise; a NOTE separating diagnostic attacks such as FGSM from those that support a robustness claim.
- Quantitative reporting and non-determinism guidance in step 4.
- A **References** block, matching the prompt injection section's pattern.

**Fixed**

- `go/testingtoolspredictiveai/` was missing its leading slash, now `/go/testingtoolspredictiveai`.
- Two typos in step headers (`succesful`, `feasiblity`).

## Note on sources

This came out of a peer review. Where the review draft and the literature disagreed, I followed the literature:

- Tramèr et al., "On Adaptive Attacks to Adversarial Example Defenses", is **NeurIPS 2020**, not ICML.
- **AutoAttack is not a substitute for adaptive attacks.** Tramèr et al. broke all thirteen defenses they selected only after tailoring each attack to the defense in front of it, and concluded that tailoring cannot be automated. RobustBench likewise describes AutoAttack and adaptive attacks as complementary rather than requiring one. The text therefore presents AutoAttack as a standardized floor you still layer a defense-specific attack on top of, and tells the reader to pick whichever ensemble is state of the art at the time of testing rather than the one named here.

Defense mechanics are deliberately left out of the testing procedure. Positive testing keeps only what the tester acts on and links to [#TRAIN ADVERSARIAL](https://owaspai.org/go/trainadversarial/), which already covers the accuracy tradeoff and overfitting.

## One change outside the evasion section

DEEPSEC is flagged as a research artifact in the tool reviews (last commit May 2019, targets PyTorch 0.4), and the table row describing it as actively maintained was corrected to match. Happy to split that out if you would rather keep this PR to the one section.