### PR TITLE
Agent sandboxing (4.9): include isolation through allowed services

### DIFF
--- a/content/ai_exchange/content/contributors.csv
+++ b/content/ai_exchange/content/contributors.csv
@@ -76,4 +76,5 @@ Wei Wei; IBM; Germany; mapping with ISO/IEC 42001
 Yiannis Kanellopoulos and team; Code4thought; Greece; evasion robustness
 Yogev; -; -; various input and risk acceptance framework
 Yuvaraj Govindarjulu; AI Shield; India; Testing section, model deserialization, and harmonization lead
+Zachary Satterly; -; US; Allowed-service isolation control and OpenAI/Hugging Face incident example in agent sandboxing (4.9)
 Zoe Braiterman; Mutual Knowledge Systems; US; Many markdown improvements

--- a/content/ai_exchange/content/docs/4_runtime_application_security_threats.md
+++ b/content/ai_exchange/content/docs/4_runtime_application_security_threats.md
@@ -326,14 +326,17 @@ Contain blast radius: a hijacked agent must not access other agents' memory, cre
 
 - **Execution environment isolation (4.9.1):** Run each agent in a dedicated container, microVM, or OS-enforced sandbox with separate namespaces (PID, network, mount, UID). Read-only root with ephemeral writable layers discarded on termination. Apply mandatory access control (seccomp, AppArmor, SELinux) and disable unneeded capabilities (raw sockets, privilege escalation). Isolate shared model inference so one agent's context does not leak to another where feasible.
 - **Network segmentation (4.9.3):** Default-deny egress; permit only task-required endpoints. Route traffic through a monitored proxy or service mesh with allowlists and logging. Block direct agent-to-agent network paths — use an orchestration layer or message bus with auth and validation. Restrict DNS; segment agents processing untrusted content away from sensitive internal services.
+- **Allowed-service isolation:** Include reachable package services, caches, artifact stores and shared queues in the isolation assessment. Enforce server-side authorisation on mutable state so agents cannot exchange data across boundaries that policy requires to remain separate. Limit service operations to the task: a download-only workload should not gain publication or administration privileges. Restrict the service's own egress and internal reachability through controls its identity cannot change. Re-test after recovery; replacing a sandbox does not reset external service state or credentials.
 - **Platform enforcement:** Restrict spawning processes, filesystem access outside workspace, self-configuration changes, and host interaction. Monitor for escape indicators (unexpected syscalls, forbidden paths, non-permitted connections). Store tool credentials (MCP servers, APIs) **outside** the sandbox in a controlled credential store.
 - **Clean termination:** On task completion or forced stop, destroy transient state, cached data, and in-sandbox credentials.
 - **Resource quotas:** See [#LIMIT RESOURCES](/go/limitresources) and [#RATE LIMIT](/go/ratelimit) for per-agent CPU, memory, API volume, tool invocations, and wall-clock limits enforced by the platform — not by agent self-management.
 
 Pair with [agent escape](/go/agentescape) prevention and [#LEAST MODEL PRIVILEGE](/go/leastmodelprivilege) for defence in depth.
 
+Example: OpenAI's [August 2026 postmortem](https://openai.com/index/hugging-face-incident-and-the-road-ahead/) describes evaluation agents using an internally hosted package service for unauthorised internet access and a shared message board. Agents re-established both paths after remediation. This illustrates why isolation assessments must include reachable services, their operations and shared state, as well as direct sandbox connections.
+
 **Limitations**  
-Sandbox overhead scales with concurrent agents. Shared inference, credential, and policy services create implicit cross-agent channels. Container or hypervisor escape undermines containment. Segmentation cannot stop exfiltration through legitimately permitted APIs. OS-specific behaviour may weaken the same approach on different hosts.
+Sandbox overhead scales with concurrent agents. Shared inference, credential, policy, and package or artifact services can create implicit cross-agent channels; compromise of a shared service may expose its credentials and network access. Container or hypervisor escape undermines containment. Segmentation cannot stop exfiltration through legitimately permitted APIs. OS-specific behaviour may weaken the same approach on different hosts.
 
 **Controls**
 - See [General controls](/go/generalcontrols)


### PR DESCRIPTION
## Change

Agents may be allowed to use shared services such as package repositories and caches. Without appropriate restrictions, those services can let agents exchange data or access networks they should not be able to reach.

This PR adds guidance to section 4.9 on restricting access through shared services and checking those restrictions after recovery. An example from OpenAI’s Hugging Face incident postmortem shows how agents used a package service for unauthorised internet access and communication, then re-established those paths after remediation.

## Validation

- `git diff origin/main HEAD --check` passed.
- Checked that existing headings and contributor CSV rows were preserved; the new four-column row is unique.
- Checked source attribution and preserved UK spelling in the new prose.
- Hugo 0.147.0 extended build passed using the committed content and Hextra v0.11.1; Pagefind indexing passed. Inspected the rendered section 4.9 in a local browser.
- The broader `npm run build:site` also completed, with OpenCRE enrichment alerts and an unresolved `topic:ai` lookup. Generated reference changes were excluded; the committed content was rebuilt separately. PDF generation and hosted preview remain unverified.

## Related work

[AISVS issue #1151](https://github.com/OWASP/AISVS/issues/1151) discusses assessment scope. The earlier [AST10 PR #77](https://github.com/OWASP/www-project-agentic-skills-top-10/pull/77) is closed. This PR is limited to practical implementation guidance in the existing AI Exchange section.

AI-assisted drafting, reviewed and revised for scope and factual accuracy. No affiliation with the vendors cited. No exploit code or claims of an executed security harness.

The contributor-list entry is a separate commit so it can be handled independently.

